### PR TITLE
Recompile all methods after updating the source code.

### DIFF
--- a/prepare_image.st
+++ b/prepare_image.st
@@ -32,6 +32,9 @@ Transcript show: 'finished.'; cr; showln: SystemVersion current printString.
 Transcript showln: 'Checking for modified versions...'.
 MCWorkingCopy checkModified: true.
 
+Transcript showln: 'Recompiling...'.
+Compiler recompileAll.
+
 ] on: ProgressNotification do: [:p | p resume]
 ] on: Warning do: [:warning | warning resume]
 ] on: MCNoChangesException do: [:ex | ex resume]


### PR DESCRIPTION
It might be sufficient to do a "Compiler recompileAll" in the base image. Not sure. Anyway, it should not take that long to recompile all methods.

Why: `Pen >> #web` cannot be decompiled at the moment because it needs recompilation.