### PR TITLE
add -p to mkdir to create intermediate subdirectories also

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -58,7 +58,7 @@ else
 fi
 
 # Create build, product, and temp folders
-mkdir "${BUILD_DIR}" "${PRODUCT_DIR}" "${TMP_DIR}"
+mkdir -p "${BUILD_DIR}" "${PRODUCT_DIR}" "${TMP_DIR}"
 
 download_and_extract_vms() {
   travis_fold start download_extract "...downloading and extracting all VMs..."

--- a/prepare_armv6.sh
+++ b/prepare_armv6.sh
@@ -15,7 +15,7 @@ VM_DIR="${BUNDLE_DIR}/bin"
 SHARED_DIR="${BUNDLE_DIR}/shared"
 
 echo "...creating directories..."
-mkdir "${BUNDLE_DIR}" "${VM_DIR}" "${SHARED_DIR}"
+mkdir -p "${BUNDLE_DIR}" "${VM_DIR}" "${SHARED_DIR}"
 
 echo "...copying ARMv6 VM..."
 cp -R "${TMP_DIR}/${VM_ARM6}/lib/squeak/"*/ "${VM_DIR}"

--- a/prepare_lin.sh
+++ b/prepare_lin.sh
@@ -15,7 +15,7 @@ VM_DIR="${BUNDLE_DIR}/bin"
 SHARED_DIR="${BUNDLE_DIR}/shared"
 
 echo "...creating directories..."
-mkdir "${BUNDLE_DIR}" "${VM_DIR}" "${SHARED_DIR}"
+mkdir -p "${BUNDLE_DIR}" "${VM_DIR}" "${SHARED_DIR}"
 
 echo "...copying Linux VM..."
 cp -R "${TMP_DIR}/${VM_LIN}/lib/squeak/"*/ "${VM_DIR}"

--- a/prepare_win.sh
+++ b/prepare_win.sh
@@ -13,7 +13,7 @@ BUNDLE_NAME_WIN="${IMAGE_NAME}-${VERSION_VM_WIN}-Windows"
 BUNDLE_DIR="${BUILD_DIR}/${BUNDLE_NAME_WIN}"
 
 echo "...creating directories..."
-mkdir "${BUNDLE_DIR}"
+mkdir -p "${BUNDLE_DIR}"
 
 echo "...copying Windows VM..."
 cp -R "${TMP_DIR}/${VM_WIN}/" "${BUNDLE_DIR}"


### PR DESCRIPTION
mkdir needs -p to create intermediate directories. It is fortuitous that current paths used in builds have no such directory.