### PR TITLE
Fix `squeak.sh` command line for running script files

### DIFF
--- a/templates/linux/squeak.sh
+++ b/templates/linux/squeak.sh
@@ -35,7 +35,7 @@ else # all-in-one bundle
 
     if [[ "${IMAGE_BITS}" == "32" ]]; then
         case "${CPU}" in
-            "x86_64")        
+            "x86_64")
                 CPU="i686"
                 echo "Running 32-bit Squeak on a 64-bit System. install-libs32 may install them."
                 ;;
@@ -55,6 +55,7 @@ STARGS=
 while [[ -n "$1" ]] ; do
     case "$1" in
          *.image) IMAGE="$1"; break;;
+         *.st|*.cs) STARGS="${STARGS} $1"; break;;
 	 --) break;;
          *) VMARGS="${VMARGS} $1";;
     esac
@@ -139,7 +140,7 @@ ensure_vm() {
 ensure_image() {
   local image_count
   # zenity is part of GNOME
-  if [[ -z "${IMAGE}" ]]; then 
+  if [[ -z "${IMAGE}" ]]; then
     image_count=$(ls "${RESOURCES}"/*.image 2>/dev/null | wc -l)
     if which zenity &>/dev/null && [[ "$image_count" -ne 1 ]]; then
       IMAGE=$(zenity --title 'Select an image' --file-selection --filename "${RESOURCES}/" --file-filter '*.image' --file-filter '*')

--- a/templates/linux/squeak.sh
+++ b/templates/linux/squeak.sh
@@ -54,8 +54,8 @@ STARGS=
 # separate vm and script arguments
 while [[ -n "$1" ]] ; do
     case "$1" in
-         *.image) IMAGE="$1"; break;;
-         *.st|*.cs) STARGS="${STARGS} $1"; break;;
+         *.image) break;;
+         *.st|*.cs) STARGS="${STARGS} $1";;
 	 --) break;;
          *) VMARGS="${VMARGS} $1";;
     esac


### PR DESCRIPTION
Since 0724852c3dc95eef554eb9bce9c8bc6da3a919c8, it was no longer possible to pass a single script file to the squeak.sh file in the AiO bundle like this:

```sh
$ ./squeak.sh /path/to/script.st
```

(Apparently, this was also never possible in the linux bundle.) With this patch, this is made possible for AiO and Linux bundles (again).

Note that the current argument parser in `squeak.sh` is limited with regard to the `IMAGE` and `STARGS` arguments: Image files are only accepted when the extension is `.image` and script files are only accepted when their extension is `.st` or `.cs`. Another limitation is that the following command would not work as expected:

```sh
$ ./squeak.sh -title my.image
# Error: my.image not found
```

Future work:

- [ ] Should we have some simple acceptance tests for this wouldn't this be worth the effort at the current stage?
- [ ] `squeak.bat` is currently unable to pass any arguments to the VM.