### PR TITLE
Changes error behavior of testing job

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -66,7 +66,7 @@ jobs:
   test-image:
     needs: [prepare-image]
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         smalltalk:
           - Squeak-trunk
@@ -114,6 +114,7 @@ jobs:
         with:
           name: ${{ matrix.smalltalk }}-tests
           path: tmp/*.xml # smalltalkCI test results
+          if-no-files-found: error # If smalltalkCI run does not complete, no output is produced
 
 
   prepare-bundles:


### PR DESCRIPTION
If no xml with test results is produced/found the testing job no fails. To prevent the complete pipeline from stopping this deactivates fail-fast for the job.

This is a draft, because I am not sure yet how reliably the absence of an .xml is with regard to a crashed test session.

(Motivation: I wanted to find out whether some tests run in CI only to find that tests do not properly run at all)