### PR TITLE
Installation instructions for Ubuntu/Gnome

### DIFF
--- a/icons/balloon.svg
+++ b/icons/balloon.svg
@@ -1,0 +1,1619 @@
+<svg viewBox="215.10263929618768 0 437.85337243401756 450.27599999999995" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" style="max-height: 500px" width="437.85337243401756" height="450.27599999999995">
+  <title>Bert's Smalltalk Balloon</title>
+
+  <desc>
+    This is my rendering of the Smalltalk Balloon. It came into being almost,
+    but not entirely, unlike the other painted and drawn renditions.
+
+    The special thing is this: The picture was created completely in Smalltalk!
+    Inspired by the famous BYTE cover I modelled the island and the balloon in 3D Studio.
+    This three dimensional model was rendered with the line drawing renderer I developed in my diploma thesis.
+
+    The Smalltalk renderer analytically calculates visible parts of the polygons in the scene.
+    The resulting pieces are colored according to the light and written to a PostScript file.
+    On top of these faces a line drawing is created by smoothly drawing contours with splines.
+    Again, the line width is adjusted to reflect the lighting (kudos to Lars Schumann for the drawing library).
+    The whole process from loading the model to writing the file took about one minute on a Pentium 90 with VisualWorks 2.5.
+
+    Bert Schoenwaelder, 1997-07-01
+  </desc>
+
+  <metadata id="license">
+
+
+        image/svg+xml
+
+
+
+
+
+
+
+
+
+
+
+
+  </metadata>
+<g>
+<path fill="#ffc93e" d="M 395.235 69.848 L 404.086 89.687 L 404.157 89.765 L 405.493 91.543" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe49d" d="M 393.383 71.388 L 400.016 86.37 L 400.677 86.661" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd976" d="M 393.794 70.29 L 401.232 87.043 L 402.504 87.934 L 403 88.483" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd976" d="M 395.235 69.848 L 393.794 70.29 L 403 88.483 L 404.086 89.687" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc93e" d="M 396.262 70.505 L 395.235 69.848 L 405.493 91.543 L 405.924 92.115" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe49d" d="M 393.794 70.29 L 393.383 71.388 L 400.677 86.661 L 400.699 86.67 L 401.232 87.043" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd875" d="M 340.913 102.687 L 341.372 101.997 L 340.346 84.839 L 340.566 103.579" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffce50" d="M 342.997 99.684 L 342.786 85.047 L 341.738 84.411 L 342.499 100.328" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdf8b" d="M 340.433 103.921 L 340.005 85.902 L 340.216 104.48" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffce50" d="M 342.373 100.492 L 342.499 100.328 L 341.738 84.411 L 341.96 101.113" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd875" d="M 341.96 101.113 L 341.738 84.411 L 340.346 84.839 L 341.372 101.997" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdf8b" d="M 340.566 103.579 L 340.346 84.839 L 340.005 85.902 L 340.433 103.921" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 24.309 230.315 L 24.065 230.864 L 25.923 231.013" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 26.858 232.07 L 25.923 231.013 L 25.932 232.147" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 24.065 230.864 L 8.533 211.937 L 24.32 231.451" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 27.535 231.71 L 25.923 231.013 L 26.858 232.07" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 27.529 230.575 L 25.923 231.013 L 27.78 231.163" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 28.773 200.726 L 18.499 201.617 L 24.986 229.953" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 8.533 211.937 L 11.423 218.468 L 24.32 231.451" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 11.085 205.749 L 8.533 211.937 L 24.065 230.864" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 25.923 231.013 L 25.003 231.921 L 25.932 232.147" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 24.309 230.315 L 11.085 205.749 L 24.065 230.864" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 27.78 231.163 L 25.923 231.013 L 27.535 231.71" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 46.441 208.689 L 26.846 230.103 L 27.529 230.575" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 24.986 229.953 L 18.499 201.617 L 24.309 230.315" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 25.923 231.013 L 24.065 230.864 L 24.32 231.451" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 46.196 221.313 L 49.018 215.276 L 27.78 231.163" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 27.529 230.575 L 26.846 230.103 L 25.923 231.013" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 18.499 201.617 L 11.085 205.749 L 24.309 230.315" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 46.196 221.313 L 27.78 231.163 L 27.535 231.71" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 49.018 215.276 L 27.529 230.575 L 27.78 231.163" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 25.923 231.013 L 24.32 231.451 L 25.003 231.921" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 25.915 229.876 L 28.773 200.726 L 24.986 229.953" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 39.037 203.336 L 28.773 200.726 L 25.915 229.876" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 39.037 203.336 L 25.915 229.876 L 26.846 230.103" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 26.846 230.103 L 25.915 229.876 L 25.923 231.013" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 24.986 229.953 L 24.309 230.315 L 25.923 231.013" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 49.018 215.276 L 46.441 208.689 L 27.529 230.575" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 46.441 208.689 L 39.037 203.336 L 26.846 230.103" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 25.915 229.876 L 24.986 229.953 L 25.923 231.013" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 54.964 273.844 L 49.874 283.728 L 78.596 319.335" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 86.809 265.731 L 68.504 267.176 L 80.348 317.91" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 79.099 318.477 L 78.596 319.335 L 81.872 319.569" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 81.872 319.569 L 80.121 320.986 L 81.736 321.339" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 79.099 318.477 L 54.964 273.844 L 78.596 319.335" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 84.778 318.883 L 81.872 319.569 L 85.144 319.802" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 85.144 319.802 L 81.872 319.569 L 84.634 320.657" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 80.348 317.91 L 68.504 267.176 L 79.099 318.477" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 84.634 320.657 L 81.872 319.569 L 83.387 321.218" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 82.008 317.789 L 86.809 265.731 L 80.348 317.91" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 114.384 298.478 L 85.144 319.802 L 84.634 320.657" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 104.602 269.956 L 82.008 317.789 L 83.63 318.145" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 84.778 318.883 L 83.63 318.145 L 81.872 319.569" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 81.872 319.569 L 78.971 320.253 L 80.121 320.986" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 116.817 278.556 L 83.63 318.145 L 84.778 318.883" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 114.384 298.478 L 120.265 289.013 L 85.144 319.802" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 49.874 283.728 L 54.292 294.032 L 78.971 320.253" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 81.872 319.569 L 78.596 319.335 L 78.971 320.253" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 83.63 318.145 L 82.008 317.789 L 81.872 319.569" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 120.265 289.013 L 84.778 318.883 L 85.144 319.802" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 116.817 278.556 L 104.602 269.956 L 83.63 318.145" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 80.348 317.91 L 79.099 318.477 L 81.872 319.569" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 68.504 267.176 L 54.964 273.844 L 79.099 318.477" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 83.387 321.218 L 81.872 319.569 L 81.736 321.339" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 78.596 319.335 L 49.874 283.728 L 78.971 320.253" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 120.265 289.013 L 116.817 278.556 L 84.778 318.883" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 104.602 269.956 L 86.809 265.731 L 82.008 317.789" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 82.008 317.789 L 80.348 317.91 L 81.872 319.569" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ababab" d="M 109.544 108.741 L 98.261 104.689 L 110.961 140.231" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 161.95 129.914 L 156.821 117.892 L 156.842 154.736" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5c5c5" d="M 30.263 96.235 L 17.941 102.396 L 26.602 126.806" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a2a2a2" d="M 147.382 110.424 L 140.8 98.782 L 140.127 134.808" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5c5c5" d="M 60.359 14.462 L 48.839 19.173 L 61.992 48.516" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#afafaf" d="M 56.418 112.585 L 48.711 142.182 L 61.959 145.336" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b2b2b2" d="M 171.033 49.617 L 150.631 42.852 L 164.124 82.807" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 134.74 123.355 L 128.298 149.482 L 132.416 160.727" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a5a5a5" d="M 147.382 110.424 L 140.127 134.808 L 151.298 141.597" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a5a5a5" d="M 153.016 173.332 L 151.427 181.054 L 146.364 191.002 L 155.615 198.331" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 138.056 188.318 L 138.46 188.946 L 146.364 191.002" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 57.492 162.294 L 36.473 155.504 L 22.765 158.851 L 46.949 165.142" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7c7c7" d="M 44.526 117.087 L 40.055 124.488 L 38.472 147.289" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 163.616 146.267 L 159.728 171.569 L 166.138 180.338" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ababab" d="M 142.366 13.676 L 133.148 48.067 L 146.186 60.421" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 155.615 198.331 L 155.218 198.884 L 155.708 199.153" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1c1c1" d="M 109.795 3.466 L 95.088 7.809 L 104.748 38.448" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1c1c0" d="M 104.748 38.448 L 90.617 42.257 L 99.415 75.417" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 145.421 166.822 L 122.443 160.907 L 122.235 163.741 L 127.138 171.357 L 151.427 181.054" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 91.821 153.023 L 61.959 145.336 L 85.494 154.732" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 158.919 216.02 L 158.777 215.572 L 158.76 216.109" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6c6c6" d="M 85.889 78.69 L 78.556 53.386 L 76.909 85.67" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 146.364 191.002 L 140.262 191.745 L 140.692 192.412" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d3d3d3" d="M 11.094 118.484 L 7.97 100.984 L 10.716 127.402" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 140.8 98.782 L 134.74 123.355 L 140.127 134.808" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bcbcbc" d="M 63.719 84.546 L 50.272 88.423 L 56.418 112.585" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bdbdbd" d="M 56.418 112.585 L 44.526 117.087 L 48.711 142.182" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbcbcb" d="M 38.472 147.289 L 40.055 124.488 L 36.473 155.504" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a2a2a2" d="M 134.74 123.355 L 122.292 111.781 L 128.298 149.482" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bababa" d="M 97.045 135.517 L 81.741 107.6 L 77.369 138.067" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4a4a4" d="M 175.829 62.95 L 171.033 49.617 L 169.083 95.496" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bcbcbc" d="M 142.366 13.676 L 122.38 15.945 L 133.148 48.067" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#aaaaaa" d="M 146.186 60.421 L 133.148 48.067 L 140.8 98.782" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9f9f9f" d="M 166.138 180.338 L 159.728 171.569 L 162.06 204.887" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a5a5a5" d="M 122.38 15.945 L 109.795 3.466 L 115.516 46.355" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0c0c0" d="M 99.415 75.417 L 90.617 42.257 L 85.889 78.69" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b1b1b1" d="M 44.545 64.488 L 25.913 63.931 L 43.464 94.975" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 139.054 189.868 L 139.391 190.391 L 146.364 191.002" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 18.815 171.215 L 12.904 170.299 L 8.536 178.933 L 17.246 179.696" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 151.427 181.054 L 127.138 171.357 L 136.267 185.539 L 146.364 191.002" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 85.494 154.732 L 61.959 145.336 L 81.38 155.843" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c2c2c2" d="M 63.719 84.546 L 49.535 52.812 L 50.272 88.423" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 22.765 158.851 L 11.919 165.014 L 12.904 170.299" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c3c3c3" d="M 21.83 33.609 L 11.213 37.86 L 25.913 63.931" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a1a1a1" d="M 159.728 171.569 L 155.615 198.331 L 162.06 204.887" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 128.298 149.482 L 110.961 140.231 L 113.586 142.738 L 115.404 143.034 L 120.462 146.087 L 122.858 149.578 L 122.96 151.693 L 132.416 160.727" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bfbfbf" d="M 56.418 112.585 L 50.272 88.423 L 44.526 117.087" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ababab" d="M 99.415 75.417 L 98.261 104.689 L 109.544 108.741" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9e9e9e" d="M 122.292 111.781 L 121.12 140.698 L 128.298 149.482" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c3c3c3" d="M 81.741 107.6 L 69.626 114.735 L 77.369 138.067" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cacaca" d="M 44.526 117.087 L 43.464 94.975 L 40.055 124.488" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 163.616 146.267 L 159.817 140.282 L 158.091 148.667 L 159.728 171.569" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 136.267 185.539 L 138.056 188.318 L 146.364 191.002" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 81.38 155.843 L 61.959 145.336 L 36.473 155.504 L 57.492 162.294" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#aaaaaa" d="M 109.795 3.466 L 104.748 38.448 L 115.516 46.355" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7c7c7" d="M 90.617 42.257 L 78.556 53.386 L 85.889 78.69" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cfcfcf" d="M 49.535 52.812 L 44.545 64.488 L 50.272 88.423" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 146.364 191.002 L 139.922 191.215 L 140.262 191.745" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1c1c1" d="M 36.473 155.504 L 26.602 126.806 L 22.765 158.851" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9b9b9b" d="M 159.605 207.149 L 159.158 207.561 L 158.919 216.02" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a9a9a9" d="M 151.308 23.938 L 142.366 13.676 L 146.186 60.421" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bebebe" d="M 99.415 75.417 L 85.889 78.69 L 98.261 104.689" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4a4a4" d="M 169.083 95.496 L 164.124 82.807 L 161.95 129.914" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#acacac" d="M 115.516 46.355 L 108.196 78.786 L 123.402 84.43" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 146.364 191.002 L 140.989 192.874 L 142.183 194.729" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bbbbbb" d="M 43.464 94.975 L 30.263 96.235 L 40.055 124.488" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a2a2a2" d="M 169.066 95.583 L 165.987 110.438 L 173.629 117.038" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1c1c1" d="M 81.741 107.6 L 76.909 85.67 L 69.626 114.735" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0c0c0" d="M 77.369 138.067 L 69.626 114.735 L 61.959 145.336" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cccccc" d="M 17.941 102.396 L 17.237 109.279 L 15 132.977" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7c7c7" d="M 22.765 158.851 L 15 132.977 L 11.919 165.014" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbcbcb" d="M 15 132.977 L 17.237 109.279 L 11.094 118.484 L 14.648 136.637" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a5a6a5" d="M 173.629 117.038 L 163.616 146.267 L 169.974 157.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9b9b9b" d="M 150.631 42.852 L 151.308 23.938 L 149.053 75.677" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a7a7a7" d="M 115.516 46.355 L 104.748 38.448 L 108.196 78.786" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 17.246 179.696 L 8.536 178.933 L 14.775 193.059" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 146.364 191.002 L 139.391 190.391 L 139.922 191.215" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cfcfcf" d="M 17.941 102.396 L 17.233 95.6 L 17.237 109.279" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b5b5b5" d="M 76.909 85.67 L 63.719 84.546 L 69.626 114.735" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a9a9a9" d="M 123.402 84.43 L 108.196 78.786 L 122.292 111.781" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a2a2a2" d="M 156.821 117.892 L 147.382 110.424 L 151.298 141.597" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#acacac" d="M 122.292 111.781 L 109.544 108.741 L 121.12 140.698" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1c1c1" d="M 48.711 142.182 L 44.526 117.087 L 38.472 147.289" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 156.842 154.736 L 151.298 141.597 L 151.427 181.054" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a1a1a1" d="M 151.308 23.938 L 146.186 60.421 L 149.053 75.677" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 132.416 160.727 L 122.614 158.586 L 122.443 160.907 L 145.421 166.822" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 94.204 152.38 L 61.959 145.336 L 91.821 153.023" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b0b0b0" d="M 104.748 38.448 L 99.415 75.417 L 108.196 78.786" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cccccc" d="M 14.278 140.487 L 9.845 147.986 L 12.027 163.897" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 146.364 191.002 L 140.692 192.412 L 140.989 192.874" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#afafaf" d="M 45.556 35.985 L 21.83 33.609 L 44.545 64.488" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6c6c6" d="M 17.233 95.6 L 15.695 80.854 L 6.351 88.682 L 17.237 109.279" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a6a6a6" d="M 140.127 134.808 L 132.416 160.727 L 145.421 166.822" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#aeaeae" d="M 60.359 14.462 L 61.992 48.516 L 78.556 53.386" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4c4c4" d="M 61.992 48.516 L 49.535 52.812 L 63.719 84.546" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b1b1b1" d="M 63.719 84.546 L 56.418 112.585 L 69.626 114.735" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#afafaf" d="M 108.196 78.786 L 109.544 108.741 L 122.292 111.781" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 121.12 140.698 L 110.961 140.231 L 128.298 149.482" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9c9c9" d="M 15.695 80.854 L 15.318 77.229 L 1.916 60.812 L 6.351 88.682" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7b7b7" d="M 109.544 108.741 L 110.961 140.231 L 121.12 140.698" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d4d4d4" d="M 6.351 88.682 L 7.97 100.984 L 11.094 118.484" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a5a6a5" d="M 183.002 89.678 L 173.629 117.038 L 178.542 127.114" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#acacac" d="M 98.261 104.689 L 97.045 135.517 L 110.961 140.231" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 138.46 188.946 L 139.054 189.868 L 146.364 191.002" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 19.474 167.65 L 20.398 165.64 L 23.682 163.578 L 27.899 162.445 L 32.471 162.477 L 36.815 163.9 L 40.346 166.925 L 46.949 165.142 L 22.765 158.851 L 12.904 170.299 L 18.815 171.215" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 156.821 117.892 L 151.298 141.597 L 156.842 154.736" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b3b3b3" d="M 21.83 33.609 L 25.913 63.931 L 44.545 64.488" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 14.775 193.059 L 8.536 178.933 L 8.318 189.223 L 14.542 194.319" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c3c3c3" d="M 61.992 48.516 L 48.839 19.173 L 49.535 52.812" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 151.298 141.597 L 145.421 166.822 L 151.427 181.054" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 122.96 151.693 L 123.023 153.004 L 122.952 153.981 L 132.416 160.727" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 110.961 140.231 L 97.045 135.517 L 106.964 142.587 L 109.743 142.111 L 113.586 142.738" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 162.06 204.887 L 155.615 198.331 L 155.708 199.153 L 156.298 199.477 L 158.602 202.002 L 159.123 204.655 L 159.027 207.681" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ababab" d="M 108.196 78.786 L 99.415 75.417 L 109.544 108.741" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 61.959 145.336 L 48.711 142.182 L 38.472 147.289" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ababab" d="M 150.631 42.852 L 149.053 75.677 L 164.124 82.807" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 155.615 198.331 L 146.364 191.002 L 144.755 196.749 L 148.266 196.477 L 152.688 197.495 L 155.218 198.884" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a3a3a3" d="M 140.8 98.782 L 123.402 84.43 L 134.74 123.355" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bdbdbd" d="M 98.261 104.689 L 81.741 107.6 L 97.045 135.517" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdcdcd" d="M 14.278 140.487 L 14.648 136.637 L 11.094 118.484 L 9.845 147.986" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 122.952 153.981 L 122.749 156.747 L 132.416 160.727" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 98.728 145.504 L 103.791 143.13 L 106.964 142.587 L 97.045 135.517 L 77.369 138.067 L 97.791 146.473" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cfcfcf" d="M 48.839 19.173 L 45.556 35.985 L 49.535 52.812" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a7a7a7" d="M 173.629 117.038 L 165.987 110.438 L 162.578 126.888 L 163.616 146.267" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b8b8b8" d="M 133.148 48.067 L 115.516 46.355 L 123.402 84.43" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bdbdbd" d="M 40.055 124.488 L 26.602 126.806 L 36.473 155.504" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6c6c6" d="M 30.263 96.235 L 14.475 69.147 L 17.941 102.396" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 144.755 196.749 L 146.364 191.002 L 142.183 194.729 L 143.544 196.843" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4a4a4" d="M 171.033 49.617 L 164.124 82.807 L 169.083 95.496" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a8a8a8" d="M 183.002 89.678 L 171.735 82.701 L 169.083 95.496 L 169.066 95.583 L 173.629 117.038" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b2b3b2" d="M 122.38 15.945 L 115.516 46.355 L 133.148 48.067" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7c7c7" d="M 50.272 88.423 L 44.545 64.488 L 43.464 94.975" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#acacac" d="M 133.148 48.067 L 123.402 84.43 L 140.8 98.782" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9b9b9" d="M 43.464 94.975 L 25.913 63.931 L 30.263 96.235" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#afafaf" d="M 164.124 82.807 L 149.053 75.677 L 156.821 117.892" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a0a0a0" d="M 123.402 84.43 L 122.292 111.781 L 134.74 123.355" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6c6c6" d="M 26.602 126.806 L 17.941 102.396 L 15 132.977" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a5a5a5" d="M 178.542 127.114 L 173.629 117.038 L 169.974 157.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5c5c5" d="M 50.272 88.423 L 43.464 94.975 L 44.526 117.087" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9f9f9f" d="M 162.578 126.888 L 161.95 129.914 L 159.817 140.282 L 163.616 146.267" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a3a3a3" d="M 158.091 148.667 L 156.842 154.736 L 154.566 165.799 L 159.728 171.569" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9e9e9e" d="M 169.974 157.24 L 163.616 146.267 L 166.138 180.338" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7c7c7" d="M 90.617 42.257 L 80.1 23.109 L 78.556 53.386" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6c6c6" d="M 26.602 126.806 L 15 132.977 L 22.765 158.851" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ababab" d="M 78.556 53.386 L 61.992 48.516 L 76.909 85.67" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4c4c4" d="M 25.913 63.931 L 14.475 69.147 L 30.263 96.235" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a5a5a5" d="M 149.053 75.677 L 147.382 110.424 L 156.821 117.892" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5c5c5" d="M 25.913 63.931 L 11.213 37.86 L 14.475 69.147" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9c9c9c" d="M 149.053 75.677 L 146.186 60.421 L 147.382 110.424" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0c0c0" d="M 104.748 38.448 L 95.088 7.809 L 90.617 42.257" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c2c2c2" d="M 14.475 69.147 L 12.931 54.332 L 1.916 60.812 L 15.318 77.229" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 61.959 145.336 L 38.472 147.289 L 36.473 155.504" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9c9c9c" d="M 159.158 207.561 L 159.027 207.681 L 158.777 215.572 L 158.919 216.02" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bbbbbb" d="M 98.261 104.689 L 85.889 78.69 L 81.741 107.6" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4a4a4" d="M 164.124 82.807 L 156.821 117.892 L 161.95 129.914" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 122.749 156.747 L 122.614 158.586 L 132.416 160.727" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0e0e0" d="M 95.344 152.072 L 95.702 148.636 L 97.791 146.473 L 77.369 138.067 L 61.959 145.336 L 94.204 152.38" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bfbfbf" d="M 40.055 124.488 L 30.263 96.235 L 26.602 126.806" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbcbcb" d="M 49.535 52.812 L 45.556 35.985 L 44.545 64.488" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a3a3a3" d="M 151.298 141.597 L 140.127 134.808 L 145.421 166.822" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a8a8a8" d="M 80.1 23.109 L 60.359 14.462 L 78.556 53.386" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b6b6b6" d="M 61.992 48.516 L 63.719 84.546 L 76.909 85.67" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdcdcd" d="M 12.904 170.299 L 11.919 165.014 L 12.027 163.897 L 9.845 147.986 L 8.536 178.933" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b3b3b3" d="M 69.626 114.735 L 56.418 112.585 L 61.959 145.336" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c8c8c8" d="M 95.088 7.809 L 80.1 23.109 L 90.617 42.257" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4a4a4" d="M 146.186 60.421 L 140.8 98.782 L 147.382 110.424" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a2a2a2" d="M 140.127 134.808 L 134.74 123.355 L 132.416 160.727" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a1a1a1" d="M 159.728 171.569 L 154.566 165.799 L 153.016 173.332 L 155.615 198.331" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cfcfcf" d="M 17.237 109.279 L 6.351 88.682 L 11.094 118.484" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5c5c5" d="M 85.889 78.69 L 76.909 85.67 L 81.741 107.6" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4a4a4" d="M 186.584 98.832 L 183.002 89.678 L 178.542 127.114" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 101.379 212.057 L 100.648 212.436 L 102.228 213.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 103.074 214.277 L 102.228 213.168 L 102.118 214.357" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 83.212 193.927 L 85.518 200.768 L 100.54 213.628" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 103.805 213.899 L 102.228 213.168 L 103.074 214.277" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 124.313 197.425 L 103.918 212.709 L 104.114 213.325" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 102.228 213.168 L 101.191 214.12 L 102.118 214.357" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 100.341 213.011 L 83.212 193.927 L 100.54 213.628" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 86.444 187.443 L 83.212 193.927 L 100.341 213.011" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 104.114 213.325 L 102.228 213.168 L 103.805 213.899" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 103.918 212.709 L 102.228 213.168 L 104.114 213.325" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 102.228 213.168 L 100.54 213.628 L 101.191 214.12" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 115.304 184.913 L 105.058 182.178 L 102.338 211.976" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 120.815 203.747 L 104.114 213.325 L 103.805 213.899" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 100.648 212.436 L 86.444 187.443 L 100.341 213.011" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 122.342 190.524 L 103.268 212.214 L 103.918 212.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 102.228 213.168 L 100.341 213.011 L 100.54 213.628" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 122.342 190.524 L 115.304 184.913 L 103.268 212.214" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 103.918 212.709 L 103.268 212.214 L 102.228 213.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 102.338 211.976 L 101.379 212.057 L 102.228 213.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 101.379 212.057 L 94.449 183.112 L 100.648 212.436" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 105.058 182.178 L 94.449 183.112 L 101.379 212.057" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 100.648 212.436 L 100.341 213.011 L 102.228 213.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 120.815 203.747 L 124.313 197.425 L 104.114 213.325" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 102.338 211.976 L 105.058 182.178 L 101.379 212.057" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 124.313 197.425 L 122.342 190.524 L 103.918 212.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 115.304 184.913 L 102.338 211.976 L 103.268 212.214" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 94.449 183.112 L 86.444 187.443 L 100.648 212.436" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 103.268 212.214 L 102.338 211.976 L 102.228 213.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe195" d="M 383.268 81.52 L 374.859 58.223 L 382.506 81.538" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc93e" d="M 376.706 56.637 L 384.971 81.549 L 385.838 81.654" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc93e" d="M 377.761 57.314 L 376.706 56.637 L 385.838 81.654 L 385.87 81.657" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd66d" d="M 376.706 56.637 L 375.254 57.093 L 384.945 81.546 L 384.971 81.549" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe195" d="M 383.295 81.519 L 375.254 57.093 L 374.859 58.223 L 383.268 81.52" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd66d" d="M 375.254 57.093 L 383.295 81.519 L 384.487 81.491 L 384.945 81.546" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 121.272 255.55 L 114.176 270.642 L 114.062 272.201" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 126.172 271.206 L 129.403 265.943 L 115.684 277.759 L 116.222 278.137" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 121.272 255.55 L 115.393 254.118 L 114.176 270.642" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 129.403 265.943 L 127.647 260.208 L 114.392 276.849 L 115.364 277.533" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 127.647 260.208 L 113.928 276.522 L 114.392 276.849" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 126.172 271.206 L 116.222 278.137 L 116.349 278.226" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 129.403 265.943 L 115.364 277.533 L 115.684 277.759" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 127.647 260.208 L 121.272 255.55 L 114.062 272.201 L 113.753 276.399 L 113.928 276.522" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e6ff83" d="M 543.624 254.227 L 528.319 243.739 L 535.893 304.1" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 353.354 102.538 L 351.329 104.101 L 352.197 112.11" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c5" d="M 445.559 440.902 L 351.634 430.312 L 445.543 440.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbbbb" d="M 530.39 400.36 L 447.361 440.652 L 447.415 440.699" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcaca" d="M 299.268 436.974 L 302.961 442.575 L 347.792 444.244" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 445.988 440.639 L 445.909 440.664 L 445.85 440.69" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffbe" d="M 487.608 383.326 L 446.908 440.522 L 446.985 440.535" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7b8ff" d="M 463.41 468.347 L 454.562 469.687 L 469.091 472.191" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ddff57" d="M 386.832 103.029 L 381.915 106.207 L 417.951 116.138" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe4bc" d="M 525.036 442.912 L 447.311 441.129 L 511.428 445.587" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1daff" d="M 446.392 440.537 L 422.066 386.747 L 446.318 440.549" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb84d" d="M 282.846 178.877 L 285.097 175.456 L 275.239 184.334" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1daff" d="M 299.441 447.915 L 282.773 435.65 L 282.726 435.633 L 303.865 455.294" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#599cff" d="M 417.199 212.022 L 425.253 251.242 L 449.836 262.461" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c8deff" d="M 374.922 313.549 L 363.934 328.642 L 393.316 353.894" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9595" d="M 608.867 268.643 L 584.375 266.779 L 592.642 315.746" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#67a4ff" d="M 384.284 174.363 L 362.377 179.728 L 391.352 208.892" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1bbff" d="M 538.219 408.847 L 447.469 440.747 L 447.499 440.78" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 349.228 92.053 L 347.33 94.149 L 351.329 104.101" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1ffba" d="M 503.159 293.891 L 479.748 298.983 L 493.15 339.582" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9ffbb" d="M 268.836 311.743 L 275.282 327.88 L 296.045 350.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 446.275 441.389 L 445.634 440.832 L 446.186 441.39" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d3ff25" d="M 391.498 101.681 L 432.821 111.948 L 445.535 113.407" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe4bb" d="M 538.114 435.234 L 447.464 441.006 L 447.436 441.038" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eb9aff" d="M 618.516 377.569 L 629.564 367.365 L 586.089 401.824" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb3b3" d="M 572.266 360.5 L 563.272 355.505 L 529.625 395.229" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 341.298 120.343 L 342.803 114.824 L 342.038 116.753 L 341.115 120.481" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.515 441.057 L 445.512 441.096" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc5c5" d="M 445.608 441.208 L 445.555 441.161 L 369.444 452.084" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7ffff" d="M 522.917 458.047 L 500.325 458.543 L 489.97 460.004" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#4690ff" d="M 373.713 116.446 L 360.694 119.875 L 377.465 138.657" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8dffff" d="M 558.677 435.724 L 558.693 435.355 L 548.335 437.68 L 539.988 447.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7a5ff" d="M 488.916 459.978 L 488.349 459.964 L 471.167 464.999 L 480.358 467.388" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7171" d="M 604.694 230.732 L 579.699 228.729 L 608.867 268.643" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ec9fff" d="M 629.196 358.557 L 593.733 387.374 L 594.427 394.046" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9fff87" d="M 313.246 283.434 L 278.327 251.881 L 288.625 288.333" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4ffb5" d="M 362.256 364.358 L 393.057 397.599 L 407.44 398.001" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe2b7" d="M 301.122 364.267 L 276.204 370.392 L 333.63 391.695" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8989" d="M 621.55 277.014 L 608.867 268.643 L 603.832 322.537" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#287eff" d="M 372.76 103.129 L 373.713 116.446 L 388.006 118.38" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 447.318 440.622 L 447.27 440.601 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 403.982 98.672 L 409.232 105.23 L 410.191 105.446" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f4ffc5" d="M 466.296 384.769 L 455.549 351.841 L 453.779 389.946" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.389 441.076 L 445.634 440.832 L 447.311 441.129" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 362.756 110.452 L 360.517 98.856 L 356.173 100.976 L 362.572 110.713" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c6" d="M 313.556 396.348 L 301.749 402.342 L 359.691 417.663" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d6ff31" d="M 432.821 111.948 L 458.559 132.647 L 475.925 134.599" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d0c4ff" d="M 446.407 441.383 L 436.001 465.948 L 445.231 468.933" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7db1ff" d="M 344.849 192.704 L 336.14 171.048 L 333.632 212.131" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eb9aff" d="M 629.564 367.365 L 594.427 394.046 L 586.089 401.824" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bdd8ff" d="M 397.19 463.258 L 445.823 441.325 L 384.382 464.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#5498ff" d="M 377.465 138.657 L 359.65 143.223 L 384.284 174.363" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 404.157 89.765 L 402.504 87.934 L 407.506 101.794" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7aafff" d="M 425.253 251.242 L 433.48 301.697 L 454.677 310.745" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5252" d="M 582.402 195.538 L 559.161 193.592 L 604.694 230.732" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ccbfff" d="M 454.562 469.687 L 445.231 468.933 L 456.331 474.106" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 364.905 96.755 L 358.199 86.853 L 360.517 98.856" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb1b1" d="M 546.61 354.398 L 541.426 318.603 L 523.342 357.604" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 344.3 112.611 L 340.913 102.687 L 342.803 114.824" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe7c2" d="M 373.213 414.699 L 359.691 417.663 L 445.712 440.778" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbebe" d="M 523.574 392.175 L 512.74 391.501 L 447.27 440.601" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc8c8" d="M 316.164 422.405 L 303.448 430.124 L 360.052 434.565" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 446.232 440.57 L 446.11 440.604 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc4" d="M 466.296 384.769 L 453.779 389.946 L 446.749 440.518" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f0ffb6" d="M 425.417 469.806 L 415.68 471.418 L 414.372 474.276" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbffbe" d="M 407.44 398.001 L 393.057 397.599 L 446.11 440.604" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e3ff73" d="M 522.322 203.95 L 499.363 201.567 L 528.319 243.739" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e1ff6a" d="M 499.363 201.567 L 458.713 173.88 L 471.753 208.392" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bcd7ff" d="M 422.14 343.542 L 391.422 303.502 L 406.365 346.556" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e784ff" d="M 635.706 313.032 L 617.017 352.003 L 629.196 358.557" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 344.822 97.325 L 342.373 100.492 L 346.811 109.418" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#71aaff" d="M 345.36 154.315 L 343.312 140.991 L 336.14 171.048" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 393.052 94.594 L 390.101 93.764 L 397.126 102.503 L 397.634 102.617" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ecffa1" d="M 522.576 295.667 L 508.232 340.868 L 518.728 346.991" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1b9ff" d="M 529.745 426.534 L 540.725 421.173 L 447.495 440.908" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9ffa7" d="M 335.697 327.761 L 288.625 288.333 L 314.115 331.754" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 445.754 441.306 L 445.823 441.325" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 342.373 100.492 L 340.913 102.687 L 344.3 112.611" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bbffff" d="M 447.231 441.182 L 447.173 441.217 L 511.668 451.138" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eeacff" d="M 594.427 394.046 L 545.841 416.194 L 540.725 421.173" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcbcb" d="M 261.786 422.819 L 266.816 429.901 L 299.268 436.974" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc6c6" d="M 445.515 441.057 L 351.036 439.673 L 347.792 444.244" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efb1ff" d="M 593.733 387.374 L 583.811 382.436 L 545.016 411.96" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d5ff2b" d="M 488.296 143.883 L 475.925 134.599 L 520.216 180.502" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f5ffca" d="M 397.19 463.258 L 384.382 464.764 L 373.87 465.578 L 379.058 471.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 343.68 118.544 L 344.3 112.611 L 342.803 114.824 L 342.959 119.088" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7aff58" d="M 310.45 143.644 L 301.493 150.535 L 291.705 174.508" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eeffab" d="M 429.539 468.752 L 436.001 465.948 L 425.417 469.806" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a1ff89" d="M 265.328 226.43 L 261.081 240.686 L 263.034 262.432" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9dfff" d="M 331.97 448.594 L 299.441 447.915 L 328.631 456.945" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9dc4ff" d="M 367.65 214.434 L 348.66 227.815 L 376.674 253.484" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1daff" d="M 422.14 343.542 L 406.365 346.556 L 432.266 384.932" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d5ffcb" d="M 334.223 373.293 L 296.045 350.941 L 330.179 381.638" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.511 440.811 L 447.499 440.78 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 370.741 94.728 L 372.76 103.129 L 377.315 103.755" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d2ffc7" d="M 381.826 399.424 L 334.223 373.293 L 374.417 403.129" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efffb0" d="M 518.728 346.991 L 508.232 340.868 L 494.504 387.01" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d83cff" d="M 619.144 253.835 L 619.592 258.153 L 632.304 278.377 L 646.273 286.892" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 341.194 119.754 L 339.758 110.274 L 339.692 113.609 L 341.095 120.106" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cabdff" d="M 446.79 441.337 L 446.705 441.358 L 471.167 464.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeaca" d="M 298.277 409.059 L 264.742 395.886 L 303.102 415.922" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 447.034 441.268 L 445.634 440.832 L 446.913 441.303" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ec9fff" d="M 629.564 367.365 L 629.196 358.557 L 594.427 394.046" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 446.186 441.39 L 446.115 441.385 L 415.68 471.418" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd79a" d="M 610.069 405.534 L 608.757 396.941 L 580.509 423.419" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0ff64" d="M 438.03 138.247 L 402.262 125.902 L 416.331 151.216" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4dcff" d="M 445.706 441.285 L 445.663 441.255 L 368.709 461.876" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9d5ff" d="M 376.674 253.484 L 357.904 265.928 L 391.422 303.502" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3586ff" d="M 397.003 141.235 L 408.248 177.393 L 431.751 189.086" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdeac" d="M 580.509 423.419 L 579.1 416.74 L 538.114 435.234" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ebff9a" d="M 528.319 243.739 L 505.847 241.525 L 522.576 295.667" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#86ff67" d="M 303.357 246.622 L 279.577 216.127 L 278.327 251.881" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c6" d="M 445.543 440.941 L 360.052 434.565 L 445.529 440.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbebe" d="M 357.257 450.709 L 331.97 448.594 L 369.444 452.084" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ceffc2" d="M 273.473 298.164 L 268.836 311.743 L 300.575 339.792" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9a9a" d="M 603.832 322.537 L 572.266 360.5 L 572.862 368.83" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d0ffc4" d="M 445.85 440.69 L 371.391 408.346 L 445.791 440.725" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 409.554 97.44 L 408.36 95.436 L 411.768 105.801 L 411.944 105.841" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeaca" d="M 301.749 402.342 L 298.277 409.059 L 351.516 421.506" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffbd" d="M 494.504 387.01 L 446.985 440.535 L 447.094 440.558" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff2a2a" d="M 455.035 120.031 L 459.2 122.936 L 478.861 128.824 L 492.948 130.09" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe4bb" d="M 534.049 439.36 L 447.389 441.076 L 525.036 442.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0daff" d="M 446.483 440.53 L 432.266 384.932 L 446.392 440.537" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff4242" d="M 539.651 156.747 L 520.564 155.077 L 582.402 195.538" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 446.749 440.518 L 446.616 440.524 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#acffff" d="M 533.931 453.637 L 539.988 447.2 L 507.749 455.521" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5050" d="M 520.564 155.077 L 486.29 142.378 L 488.296 143.883 L 501.15 158.629" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9b9b" d="M 584.375 266.779 L 549.804 272.168 L 571.359 314.237" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#4f95ff" d="M 408.248 177.393 L 384.284 174.363 L 417.199 212.022" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffbf" d="M 479.748 298.983 L 454.677 310.745 L 475.029 343.271" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdaa3" d="M 275.282 327.88 L 247.219 335.266 L 301.122 364.267" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 404.157 89.765 L 407.506 101.794 L 408.543 103.161 L 409.572 104.377" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe3ba" d="M 536.824 430.847 L 447.48 440.966 L 447.464 441.006" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 387.419 93.445 L 384.063 93.524 L 391.498 101.681" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb8b8" d="M 563.272 355.505 L 546.61 354.398 L 523.574 392.175" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc66f" d="M 258.523 276.995 L 259.727 259.909 L 240.78 265.453 L 262.754 291.249" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.524 441.127 L 445.555 441.161" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5dcff" d="M 445.663 441.255 L 445.608 441.208 L 366.741 457.787" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 258.122 386.998 L 235.63 365.782 L 264.742 395.886" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3485ff" d="M 388.006 118.38 L 373.713 116.446 L 397.003 141.235" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdfb0" d="M 560.347 434.984 L 574.02 429.654 L 525.036 442.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#4f95ff" d="M 368.607 104.24 L 365.209 106.978 L 360.694 119.875" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa4a4" d="M 572.862 368.83 L 530.39 400.36 L 525.503 407.235" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bed8ff" d="M 374.755 464.246 L 340.91 466.305 L 354.879 467.049" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#deff5a" d="M 538.028 215.233 L 522.322 203.95 L 543.624 254.227" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b2ff9f" d="M 278.327 251.881 L 263.034 262.432 L 288.625 288.333" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 316.164 422.405 L 266.375 414.11 L 303.448 430.124" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a1ff89" d="M 263.034 262.432 L 261.081 240.686 L 258.523 276.995" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 376.343 81.93 L 371.482 82.328 L 379.088 93.889" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6fa9ff" d="M 391.352 208.892 L 399.961 248.332 L 425.253 251.242" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 400.699 86.67 L 403.982 98.672 L 405.823 99.946" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#accdff" d="M 439.083 345.243 L 443.161 385.956 L 453.779 389.946" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9ffa7" d="M 363.934 328.642 L 335.697 327.761 L 384.371 365.01" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.464 441.006 L 445.634 440.832 L 447.436 441.038" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 364.905 96.755 L 360.517 98.856 L 365.209 106.978" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe5c0" d="M 333.63 391.695 L 313.556 396.348 L 373.213 414.699" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1baff" d="M 525.503 407.235 L 447.415 440.699 L 447.469 440.747" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cec1ff" d="M 446.54 441.377 L 445.231 468.933 L 454.562 469.687" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 446.54 441.377 L 445.634 440.832 L 446.407 441.383" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 266.375 414.11 L 233.824 397.642 L 261.786 422.819" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb94f" d="M 625.39 371.22 L 625.342 371.264 L 626.052 377.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f4ffc6" d="M 445.93 441.349 L 397.19 463.258 L 400.958 468.151" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeaca" d="M 298.277 409.059 L 303.102 415.922 L 348.807 425.844" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6ca7ff" d="M 359.65 143.223 L 345.36 154.315 L 362.377 179.728" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7a5ff" d="M 488.349 459.964 L 477.181 459.684 L 471.167 464.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#93beff" d="M 399.961 248.332 L 411.644 299.356 L 433.48 301.697" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d8ff3d" d="M 458.559 132.647 L 484.149 167.282 L 505.437 169.584" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 347.33 94.149 L 344.822 97.325 L 349.383 106.215" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#acffff" d="M 539.988 447.2 L 511.668 451.138 L 507.749 455.521" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 370.741 94.728 L 365.501 83.491 L 367.994 95.464" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e2ff6e" d="M 543.624 254.227 L 535.893 304.1 L 541.426 318.603" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 349.156 114.407 L 349.383 106.215 L 348.303 115.052" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 579.699 228.729 L 544.474 234.52 L 584.375 266.779" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe7c4" d="M 359.691 417.663 L 351.516 421.506 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcaca" d="M 351.036 439.673 L 299.268 436.974 L 347.792 444.244" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eca2ff" d="M 629.196 358.557 L 617.017 352.003 L 593.733 387.374" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 406.288 92.599 L 409.609 104.421 L 410.543 105.525 L 411.096 105.649" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 446.11 440.604 L 445.988 440.639 L 445.712 440.778" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc2" d="M 477.899 382.556 L 466.296 384.769 L 446.838 440.517" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ccffc0" d="M 393.057 397.599 L 345.185 367.316 L 381.826 399.424" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 302.961 442.575 L 280.71 434.928 L 313.986 446.567" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#227aff" d="M 377.315 103.755 L 388.006 118.38 L 402.262 125.902" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7ddff" d="M 413.501 391.194 L 407.44 398.001 L 446.232 440.57" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 447.201 440.582 L 447.094 440.558 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#5e9fff" d="M 360.694 119.875 L 350.192 128.247 L 359.65 143.223" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5a5a" d="M 559.161 193.592 L 508.95 167.578 L 520.216 180.502 L 529.555 198.711" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5dcff" d="M 303.865 455.294 L 315.057 459.529 L 331.92 462.883" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dcff4f" d="M 484.149 167.282 L 499.363 201.567 L 522.322 203.95" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff2929" d="M 539.651 156.747 L 582.402 195.538 L 594.709 204.283" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e786ff" d="M 635.706 313.032 L 613.8 309.715 L 610.23 318.529 L 617.017 352.003" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7eb2ff" d="M 367.65 214.434 L 344.849 192.704 L 348.66 227.815" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#67ff41" d="M 343.312 140.991 L 324.67 140.241 L 336.14 171.048" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 389.998 82.629 L 393.052 94.594 L 397.213 96.043" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efffb0" d="M 503.159 293.891 L 493.15 339.582 L 508.232 340.868" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7979" d="M 621.448 290.832 L 621.55 277.014 L 604.048 333.794" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9ffbb" d="M 314.115 331.754 L 273.473 298.164 L 300.575 339.792" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 356.173 100.976 L 353.354 102.538 L 356.863 110.965" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#baffff" d="M 447.311 441.129 L 447.231 441.182 L 511.428 445.587" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 386.832 103.029 L 379.088 93.889 L 381.915 106.207" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffacac" d="M 572.266 360.5 L 529.625 395.229 L 530.39 400.36" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcf87" d="M 220.912 312.301 L 222.298 286.492 L 217.267 323.509" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.559 440.902 L 445.543 440.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd89f" d="M 610.069 405.534 L 580.509 423.419 L 574.02 429.654" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc5c5" d="M 445.512 441.096 L 347.792 444.244 L 349.965 448.009" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6ddff" d="M 374.755 464.246 L 368.709 461.876 L 340.91 466.305" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bcd7ff" d="M 301.385 442.16 L 288.676 437.714 L 299.441 447.915" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbcbc" d="M 529.625 395.229 L 523.574 392.175 L 447.318 440.622" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d0c4ff" d="M 445.231 468.933 L 436.001 465.948 L 442.891 473.03" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd79a" d="M 608.757 396.941 L 579.1 416.74 L 580.509 423.419" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a2c7ff" d="M 348.66 227.815 L 336.488 247.784 L 357.904 265.928" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7ddff" d="M 406.365 346.556 L 393.316 353.894 L 422.066 386.747" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d4ffc9" d="M 330.179 381.638 L 301.122 364.267 L 333.63 391.695" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 371.482 82.328 L 368.185 82.762 L 374.115 94.29" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e8ff89" d="M 499.363 201.567 L 471.753 208.392 L 505.847 241.525" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.469 440.747 L 447.415 440.699 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 401.332 97.522 L 397.213 96.043 L 403.92 104.033 L 404.985 104.273" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1ffb9" d="M 508.232 340.868 L 493.15 339.582 L 487.608 383.326" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb94f" d="M 625.406 371.205 L 625.39 371.22 L 626.052 377.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 351.204 90.503 L 349.228 92.053 L 353.354 102.538" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5dcff" d="M 406.365 346.556 L 374.922 313.549 L 393.316 353.894" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#63ff3c" d="M 356.863 110.965 L 352.197 112.11 L 324.67 140.241" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 447.173 441.217 L 445.634 440.832 L 447.114 441.243" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeacb" d="M 301.749 402.342 L 258.122 386.998 L 298.277 409.059" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1baff" d="M 540.725 421.173 L 545.841 416.194 L 447.508 440.85" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d6ff31" d="M 445.535 113.407 L 432.821 111.948 L 475.925 134.599" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc0" d="M 446.275 441.389 L 446.186 441.39 L 425.417 469.806" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 445.93 441.349 L 446.038 441.372" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4dbff" d="M 445.754 441.306 L 445.706 441.285 L 374.755 464.246" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3f8cff" d="M 377.465 138.657 L 384.284 174.363 L 408.248 177.393" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eeffa9" d="M 505.847 241.525 L 478.74 247.868 L 503.159 293.891" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#96ff7c" d="M 278.327 251.881 L 265.328 226.43 L 263.034 262.432" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cce0ff" d="M 369.444 452.084 L 328.631 456.945 L 366.741 457.787" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa5a5" d="M 603.832 322.537 L 592.642 315.746 L 572.266 360.5" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 341.608 118.283 L 339.872 106.909 L 339.758 110.274 L 341.576 118.396" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5e5e" d="M 617.679 239.726 L 604.694 230.732 L 621.55 277.014" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d1ffc5" d="M 445.791 440.725 L 373.213 414.699 L 445.712 440.778" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe9c7" d="M 351.634 430.312 L 316.164 422.405 L 360.052 434.565" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb7c" d="M 240.78 265.453 L 225.788 275.416 L 236.885 302.197" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff2a2a" d="M 454.164 119.424 L 455.035 120.031 L 492.948 130.09" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 446.483 440.53 L 446.392 440.537 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0d9ff" d="M 446.616 440.524 L 443.161 385.956 L 446.483 440.53" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cfffc3" d="M 445.988 440.639 L 381.826 399.424 L 445.909 440.664" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cabcff" d="M 446.913 441.303 L 446.79 441.337 L 477.181 459.684" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#418dff" d="M 431.751 189.086 L 408.248 177.393 L 442.407 224.088" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff2929" d="M 550.129 164.27 L 539.651 156.747 L 594.709 204.283" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe2b8" d="M 247.219 335.266 L 231.374 344.706 L 276.204 370.392" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc062" d="M 259.727 259.909 L 261.081 240.686 L 262.618 235.525 L 258.793 217.764 L 240.78 265.453" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#2c80ff" d="M 402.262 125.902 L 388.006 118.38 L 416.331 151.216" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#78ff56" d="M 310.87 170.068 L 291.705 174.508 L 302.843 210.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 387.419 93.445 L 391.498 101.681 L 395.556 102.149" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbcbc" d="M 546.61 354.398 L 523.342 357.604 L 512.74 391.501" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b2ff9f" d="M 288.625 288.333 L 263.034 262.432 L 273.473 298.164" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bad5ff" d="M 357.904 265.928 L 345.724 284.516 L 374.922 313.549" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bdffff" d="M 447.114 441.243 L 447.034 441.268 L 500.325 458.543" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdda9" d="M 579.1 416.74 L 569.01 410.123 L 536.824 430.847" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc5c5" d="M 445.529 440.999 L 351.036 439.673 L 445.515 441.057" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efb2ff" d="M 564.652 379.869 L 525.503 407.235 L 538.219 408.847" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbdbd" d="M 497.762 393.456 L 447.094 440.558 L 447.201 440.582" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc4" d="M 361.997 466.498 L 361.962 466.501 L 373.321 471.189 L 379.058 471.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcf87" d="M 268.836 311.743 L 263.784 294.721 L 236.885 302.197 L 275.282 327.88" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc4" d="M 379.058 471.912 L 373.321 471.189 L 388.397 475.778" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcbcb" d="M 303.448 430.124 L 261.786 422.819 L 299.268 436.974" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8ab9ff" d="M 399.961 248.332 L 367.65 214.434 L 376.674 253.484" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7d4ff" d="M 422.14 343.542 L 432.266 384.932 L 443.161 385.956" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7ffb9" d="M 335.697 327.761 L 314.115 331.754 L 362.256 364.358" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dbff4b" d="M 544.474 234.52 L 538.028 215.233 L 549.804 272.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.495 440.908 L 445.634 440.832 L 447.48 440.966" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 367.994 95.464 L 364.905 96.755 L 368.607 104.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#edffa6" d="M 518.728 346.991 L 494.504 387.01 L 497.762 393.456" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffddaa" d="M 231.374 344.706 L 217.267 323.509 L 227.619 355.183" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#99c2ff" d="M 454.677 310.745 L 433.48 301.697 L 455.549 351.841" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff4444" d="M 478.861 128.824 L 460.946 124.154 L 470.052 130.503" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 446.705 441.358 L 445.634 440.832 L 446.631 441.37" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb4b4" d="M 281.171 404.467 L 278.301 402.968 L 238.5 387.382 L 266.375 414.11" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe3ba" d="M 529.745 426.534 L 447.495 440.908 L 447.48 440.966" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9b9b" d="M 229.39 357.527 L 228.875 357.913 L 230.533 359.039" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc4" d="M 446.038 441.372 L 400.958 468.151 L 407.334 470.86" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbe5d" d="M 258.793 217.764 L 275.239 184.334 L 246.088 226.625" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 445.608 441.208 L 445.663 441.255" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d5ff2b" d="M 475.925 134.599 L 505.437 169.584 L 520.216 180.502" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#deff59" d="M 458.559 132.647 L 438.03 138.247 L 484.149 167.282" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 379.088 93.889 L 371.482 82.328 L 374.115 94.29" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e6ff83" d="M 528.319 243.739 L 522.576 295.667 L 535.893 304.1" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8ab9ff" d="M 348.66 227.815 L 333.632 212.131 L 336.488 247.784" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcaca" d="M 347.792 444.244 L 302.961 442.575 L 349.965 448.009" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eca1ff" d="M 617.017 352.003 L 592.93 348.584 L 583.811 382.436" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#4f95ff" d="M 360.694 119.875 L 365.209 106.978 L 350.192 128.247" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 445.988 440.639 L 445.85 440.69 L 445.791 440.725" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffbf" d="M 487.608 383.326 L 477.899 382.556 L 446.908 440.522" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d2ffc7" d="M 345.185 367.316 L 334.223 373.293 L 381.826 399.424" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#de5cff" d="M 632.304 278.377 L 635.706 313.032 L 649.379 320.977" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9affff" d="M 550.97 443.788 L 558.677 435.724 L 533.931 453.637" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ddff57" d="M 417.951 116.138 L 381.915 106.207 L 402.262 125.902" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4dcff" d="M 422.066 386.747 L 413.501 391.194 L 446.318 440.549" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 446.985 440.535 L 446.908 440.522 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7979" d="M 621.55 277.014 L 603.832 322.537 L 604.048 333.794" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cadfff" d="M 366.741 457.787 L 328.631 456.945 L 331.92 462.883" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d6ffcb" d="M 330.179 381.638 L 333.63 391.695 L 371.391 408.346" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbbeff" d="M 463.41 468.347 L 446.631 441.37 L 454.562 469.687" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#67a4ff" d="M 391.352 208.892 L 362.377 179.728 L 367.65 214.434" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9595" d="M 584.375 266.779 L 571.359 314.237 L 592.642 315.746" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1ffba" d="M 493.15 339.582 L 479.748 298.983 L 475.029 343.271" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9ffbb" d="M 296.045 350.941 L 275.282 327.88 L 301.122 364.267" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff4242" d="M 520.564 155.077 L 559.161 193.592 L 582.402 195.538" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe4bb" d="M 534.049 439.36 L 447.436 441.038 L 447.389 441.076" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 391.498 101.681 L 384.063 93.524 L 386.832 103.029" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb3b3" d="M 563.272 355.505 L 523.574 392.175 L 529.625 395.229" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#accdff" d="M 411.644 299.356 L 376.674 253.484 L 391.422 303.502" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.529 440.999 L 445.515 441.057" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc4c4" d="M 445.524 441.127 L 349.965 448.009 L 357.257 450.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 353.354 102.538 L 349.228 92.053 L 351.329 104.101" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4ffff" d="M 539.988 447.2 L 540.07 439.536 L 537.33 440.151 L 511.668 451.138" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 238.5 387.382 L 233.824 397.642 L 266.375 414.11" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#5eff36" d="M 356.863 110.965 L 324.67 140.241 L 343.312 140.991" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 352.197 112.11 L 351.329 104.101 L 349.165 114.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c5" d="M 351.516 421.506 L 348.807 425.844 L 445.586 440.869" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbaba" d="M 530.39 400.36 L 529.625 395.229 L 447.361 440.652" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e0ff64" d="M 417.951 116.138 L 402.262 125.902 L 438.03 138.247" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0b0ff" d="M 480.358 467.388 L 471.167 464.999 L 463.41 468.347" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#86ff68" d="M 291.705 174.508 L 279.83 183.461 L 279.577 216.127" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7b8ff" d="M 469.091 472.191 L 454.562 469.687 L 456.331 474.106" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 384.487 81.491 L 381.206 81.569 L 387.419 93.445" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8cff70" d="M 336.488 247.784 L 303.357 246.622 L 345.724 284.516" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe2b7" d="M 333.63 391.695 L 276.204 370.392 L 313.556 396.348" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eaff94" d="M 471.753 208.392 L 442.407 224.088 L 478.74 247.868" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 403.982 98.672 L 401.332 97.522 L 408.713 105.113 L 409.232 105.23" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc0" d="M 493.15 339.582 L 475.029 343.271 L 477.899 382.556" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c8deff" d="M 393.316 353.894 L 363.934 328.642 L 384.371 365.01" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 447.311 441.129 L 445.634 440.832 L 447.231 441.182" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1bbff" d="M 545.841 416.194 L 545.016 411.96 L 447.511 440.811" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 227.619 355.183 L 235.63 365.782 L 258.122 386.998" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d8ff3d" d="M 475.925 134.599 L 458.559 132.647 L 505.437 169.584" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 446.115 441.385 L 446.186 441.39" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eeacff" d="M 586.089 401.824 L 594.427 394.046 L 540.725 421.173" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d8ff3e" d="M 391.498 101.681 L 386.832 103.029 L 432.821 111.948" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 340.955 120.602 L 341.095 120.106 L 339.692 113.609 L 340.766 120.745" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c3dbff" d="M 445.823 441.325 L 445.754 441.306 L 384.382 464.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6bffff" d="M 558.782 435.335 L 558.693 435.355 L 558.677 435.724" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#beffff" d="M 500.325 458.543 L 447.034 441.268 L 489.97 460.004" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5252" d="M 559.161 193.592 L 579.699 228.729 L 604.694 230.732" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 360.517 98.856 L 353.958 88.954 L 356.173 100.976" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffadad" d="M 592.642 315.746 L 571.359 314.237 L 563.272 355.505" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7171" d="M 579.699 228.729 L 584.375 266.779 L 608.867 268.643" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc8c8" d="M 360.052 434.565 L 303.448 430.124 L 351.036 439.673" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd494" d="M 608.757 396.941 L 600.439 391.09 L 590.184 398.761 L 579.1 416.74" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 446.318 440.549 L 446.232 440.57 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffc0" d="M 446.749 440.518 L 453.779 389.946 L 446.616 440.524" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbe0ff" d="M 393.316 353.894 L 384.371 365.01 L 413.501 391.194" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3887ff" d="M 372.76 103.129 L 368.607 104.24 L 373.713 116.446" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 447.361 440.652 L 447.318 440.622 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cfffc3" d="M 446.11 440.604 L 393.057 397.599 L 445.988 440.639" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff3636" d="M 492.948 130.09 L 478.861 128.824 L 539.651 156.747" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e5ff7d" d="M 458.713 173.88 L 431.751 189.086 L 471.753 208.392" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c4" d="M 313.556 396.348 L 261.88 378.247 L 301.749 402.342" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffc0" d="M 446.407 441.383 L 446.275 441.389 L 436.001 465.948" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc875" d="M 619.829 376.356 L 618.516 377.569 L 609.565 384.264 L 608.757 396.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6fff4b" d="M 336.14 171.048 L 310.87 170.068 L 333.632 212.131" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#5e9fff" d="M 359.65 143.223 L 350.192 128.247 L 345.36 154.315" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 390.101 93.764 L 395.556 102.149 L 397.126 102.503" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e9ff8f" d="M 541.426 318.603 L 535.893 304.1 L 523.342 357.604" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 362.485 84.771 L 358.199 86.853 L 364.905 96.755" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4ff8e" d="M 345.724 284.516 L 313.246 283.434 L 363.934 328.642" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#5498ff" d="M 384.284 174.363 L 359.65 143.223 L 362.377 179.728" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bcffff" d="M 507.749 455.521 L 447.114 441.243 L 500.325 458.543" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 374.115 94.29 L 377.315 103.755 L 381.915 106.207" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eea8ff" d="M 569.01 410.123 L 586.089 401.824 L 529.745 426.534" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 387.419 93.445 L 381.206 81.569 L 384.063 93.524" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efffae" d="M 478.74 247.868 L 449.836 262.461 L 479.748 298.983" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc5c5" d="M 445.512 441.096 L 445.515 441.057 L 347.792 444.244" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efb1ff" d="M 583.811 382.436 L 538.219 408.847 L 545.016 411.96" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffc0" d="M 415.68 471.418 L 407.334 470.86 L 400.425 476.573" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 342.959 119.088 L 342.803 114.824 L 341.298 120.343" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 342.803 114.824 L 340.169 104.601 L 342.038 116.753" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c5" d="M 445.712 440.778 L 359.691 417.663 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbdbd" d="M 512.74 391.501 L 447.201 440.582 L 447.27 440.601" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f4ffc6" d="M 407.334 470.86 L 400.958 468.151 L 388.397 475.778" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f0ffb6" d="M 414.372 474.276 L 415.68 471.418 L 400.425 476.573" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9dc4ff" d="M 376.674 253.484 L 348.66 227.815 L 357.904 265.928" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d1ffc6" d="M 314.115 331.754 L 300.575 339.792 L 345.185 367.316" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e3ff73" d="M 499.363 201.567 L 505.847 241.525 L 528.319 243.739" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d52dff" d="M 618.373 246.416 L 618.51 247.729 L 622.754 250.398" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 370.741 94.728 L 367.994 95.464 L 372.76 103.129" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#96ff7c" d="M 279.577 216.127 L 265.328 226.43 L 278.327 251.881" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 406.288 92.599 L 404.157 89.765 L 409.572 104.377 L 409.609 104.421" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#accdff" d="M 433.48 301.697 L 411.644 299.356 L 439.083 345.243" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#de5cff" d="M 646.273 286.892 L 632.304 278.377 L 649.379 320.977" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efffb0" d="M 508.232 340.868 L 487.608 383.326 L 494.504 387.01" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 446.913 441.303 L 445.634 440.832 L 446.79 441.337" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1baff" d="M 540.725 421.173 L 447.508 440.85 L 447.495 440.908" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa7a7" d="M 228.875 357.913 L 224.293 368.862 L 238.5 387.382" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 446.115 441.385 L 407.334 470.86 L 415.68 471.418" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 445.706 441.285 L 445.754 441.306" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6bffff" d="M 558.83 435.324 L 558.782 435.335 L 558.677 435.724" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc875" d="M 609.565 384.264 L 600.439 391.09 L 608.757 396.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5ddff" d="M 445.663 441.255 L 366.741 457.787 L 368.709 461.876" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc4c4" d="M 261.786 422.819 L 239.873 405.956 L 266.816 429.901" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e2ff6f" d="M 438.03 138.247 L 416.331 151.216 L 458.713 173.88" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f5ffca" d="M 400.958 468.151 L 397.19 463.258 L 379.058 471.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ebff9a" d="M 505.847 241.525 L 503.159 293.891 L 522.576 295.667" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#79ff57" d="M 333.632 212.131 L 302.843 210.999 L 336.488 247.784" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc6c6" d="M 349.965 448.009 L 313.986 446.567 L 357.257 450.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8d8d" d="M 592.93 348.584 L 604.048 333.794 L 564.652 379.869" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd79b" d="M 236.885 302.197 L 220.912 312.301 L 247.219 335.266" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d0ffc4" d="M 445.909 440.664 L 374.417 403.129 L 445.85 440.69" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeaca" d="M 351.516 421.506 L 298.277 409.059 L 348.807 425.844" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcbcb" d="M 299.268 436.974 L 266.816 429.901 L 302.961 442.575" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff4444" d="M 459.2 122.936 L 460.946 124.154 L 478.861 128.824" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 446.838 440.517 L 446.749 440.518 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1daff" d="M 432.266 384.932 L 422.066 386.747 L 446.392 440.537" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1daff" d="M 432.266 384.932 L 406.365 346.556 L 422.066 386.747" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbe0ff" d="M 299.441 447.915 L 303.865 455.294 L 328.631 456.945" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.511 440.811 L 445.634 440.832 L 447.508 440.85" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d5ffcb" d="M 334.223 373.293 L 330.179 381.638 L 374.417 403.129" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9bbff" d="M 471.167 464.999 L 446.705 441.358 L 463.41 468.347" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#4f95ff" d="M 384.284 174.363 L 391.352 208.892 L 417.199 212.022" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 384.487 81.491 L 387.419 93.445 L 390.101 93.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdaa3" d="M 301.122 364.267 L 247.219 335.266 L 276.204 370.392" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbc58" d="M 269.358 214.49 L 278.521 187.34 L 258.793 217.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dbff4c" d="M 432.821 111.948 L 417.951 116.138 L 458.559 132.647" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb8b8" d="M 546.61 354.398 L 512.74 391.501 L 523.574 392.175" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d52dff" d="M 618.341 246.1 L 618.373 246.416 L 622.754 250.398" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9d5ff" d="M 391.422 303.502 L 357.904 265.928 L 374.922 313.549" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc2c2" d="M 445.555 441.161 L 357.257 450.709 L 369.444 452.084" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdeac" d="M 579.1 416.74 L 536.824 430.847 L 538.114 435.234" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 384.063 93.524 L 376.343 81.93 L 379.088 93.889" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3485ff" d="M 373.713 116.446 L 377.465 138.657 L 397.003 141.235" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 356.863 110.965 L 353.354 102.538 L 352.197 112.11" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c5" d="M 348.807 425.844 L 351.634 430.312 L 445.559 440.902" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 408.36 95.436 L 406.288 92.599 L 411.096 105.649 L 411.265 105.688" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb7b7" d="M 525.503 407.235 L 530.39 400.36 L 447.415 440.699" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1ffbb" d="M 494.504 387.01 L 487.608 383.326 L 446.985 440.535" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0b0ff" d="M 480.358 467.388 L 463.41 468.347 L 469.091 472.191" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe4bb" d="M 447.389 441.076 L 447.311 441.129 L 525.036 442.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#599cff" d="M 442.407 224.088 L 417.199 212.022 L 449.836 262.461" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9ffa7" d="M 335.697 327.761 L 362.256 364.358 L 384.371 365.01" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9b9b" d="M 571.359 314.237 L 549.804 272.168 L 541.426 318.603" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 365.209 106.978 L 360.517 98.856 L 362.756 110.452" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1bcff" d="M 545.016 411.96 L 538.219 408.847 L 447.499 440.78" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffbf" d="M 475.029 343.271 L 454.677 310.745 L 455.549 351.841" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#63ff3c" d="M 324.67 140.241 L 352.197 112.11 L 310.45 143.644" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 446.407 441.383 L 445.634 440.832 L 446.275 441.389" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc4c4" d="M 233.824 397.642 L 239.873 405.956 L 261.786 422.819" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d3ff25" d="M 395.556 102.149 L 391.498 101.681 L 445.535 113.407" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffca79" d="M 626.052 377.24 L 625.342 371.264 L 622.054 374.301 L 610.069 405.534" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe4bb" d="M 534.049 439.36 L 538.114 435.234 L 447.436 441.038" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc66f" d="M 263.784 294.721 L 262.754 291.249 L 240.78 265.453 L 236.885 302.197" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c3dbff" d="M 445.93 441.349 L 445.823 441.325 L 397.19 463.258" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.512 441.096 L 445.524 441.127" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7ffff" d="M 522.917 458.047 L 489.97 460.004 L 507.791 460.17" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1daff" d="M 288.676 437.714 L 282.773 435.65 L 299.441 447.915" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff6767" d="M 579.699 228.729 L 531.091 201.707 L 538.028 215.233 L 544.474 234.52" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 367.994 95.464 L 362.485 84.771 L 364.905 96.755" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb1b1" d="M 571.359 314.237 L 541.426 318.603 L 546.61 354.398" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f4ffc7" d="M 373.87 465.578 L 361.997 466.498 L 379.058 471.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 584.375 266.779 L 544.474 234.52 L 549.804 272.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eca2ff" d="M 617.017 352.003 L 583.811 382.436 L 593.733 387.374" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9fff87" d="M 303.357 246.622 L 278.327 251.881 L 313.246 283.434" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 446.11 440.604 L 445.712 440.778 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4ffb5" d="M 384.371 365.01 L 362.256 364.358 L 407.44 398.001" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c4" d="M 276.204 370.392 L 261.88 378.247 L 313.556 396.348" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5e5e" d="M 604.694 230.732 L 608.867 268.643 L 621.55 277.014" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#287eff" d="M 377.315 103.755 L 372.76 103.129 L 388.006 118.38" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 447.27 440.601 L 447.201 440.582 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 405.823 99.946 L 403.982 98.672 L 410.191 105.446 L 410.543 105.525" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f4ffc5" d="M 475.029 343.271 L 455.549 351.841 L 466.296 384.769" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c3dbff" d="M 446.232 440.57 L 407.44 398.001 L 446.11 440.604" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b2ffff" d="M 522.917 458.047 L 533.931 453.637 L 500.325 458.543" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e1ff6a" d="M 484.149 167.282 L 458.713 173.88 L 499.363 201.567" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 347.66 115.537 L 346.811 109.418 L 344.3 112.611 L 346.262 116.593" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe5c0" d="M 373.213 414.699 L 313.556 396.348 L 359.691 417.663" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.436 441.038 L 445.634 440.832 L 447.389 441.076" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff3a3a" d="M 594.709 204.283 L 582.402 195.538 L 617.679 239.726" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ccc0ff" d="M 446.54 441.377 L 446.407 441.383 L 445.231 468.933" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8ab9ff" d="M 344.849 192.704 L 333.632 212.131 L 348.66 227.815" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#67ff41" d="M 324.67 140.241 L 310.87 170.068 L 336.14 171.048" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 400.699 86.67 L 398.104 85.531 L 403.982 98.672" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9ffa7" d="M 313.246 283.434 L 288.625 288.333 L 335.697 327.761" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6ca7ff" d="M 362.377 179.728 L 345.36 154.315 L 344.849 192.704" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 379.088 93.889 L 374.115 94.29 L 381.915 106.207" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efafff" d="M 594.427 394.046 L 593.733 387.374 L 545.841 416.194" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7aafff" d="M 449.836 262.461 L 425.253 251.242 L 454.677 310.745" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc5c5" d="M 445.524 441.127 L 445.512 441.096 L 349.965 448.009" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efafff" d="M 593.733 387.374 L 545.016 411.96 L 545.841 416.194" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 397.213 96.043 L 393.052 94.594 L 397.634 102.617 L 399.019 102.929" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b2ffff" d="M 533.931 453.637 L 507.749 455.521 L 500.325 458.543" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 346.262 116.593 L 344.3 112.611 L 343.68 118.544" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8dffff" d="M 548.335 437.68 L 540.07 439.536 L 539.988 447.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 348.303 115.052 L 349.383 106.215 L 346.811 109.418 L 347.66 115.537" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbcbc" d="M 523.574 392.175 L 447.27 440.601 L 447.318 440.622" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c5" d="M 445.634 440.832 L 351.516 421.506 L 445.586 440.869" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d0c4ff" d="M 436.001 465.948 L 429.539 468.752 L 442.891 473.03" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbe5d" d="M 278.521 187.34 L 279.83 183.461 L 282.846 178.877 L 275.239 184.334 L 258.793 217.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffc0" d="M 446.838 440.517 L 466.296 384.769 L 446.749 440.518" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eeffab" d="M 429.539 468.752 L 425.417 469.806 L 414.372 474.276" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a2c7ff" d="M 357.904 265.928 L 336.488 247.784 L 345.724 284.516" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d5ffcb" d="M 300.575 339.792 L 296.045 350.941 L 334.223 373.293" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e8ff89" d="M 505.847 241.525 L 471.753 208.392 L 478.74 247.868" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 394.071 84.065 L 397.213 96.043 L 401.332 97.522" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1ffb9" d="M 493.15 339.582 L 477.899 382.556 L 487.608 383.326" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bcd7ff" d="M 411.644 299.356 L 391.422 303.502 L 422.14 343.542" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcf87" d="M 225.788 275.416 L 222.298 286.492 L 220.912 312.301" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e786ff" d="M 610.23 318.529 L 604.048 333.794 L 592.93 348.584 L 617.017 352.003" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 447.114 441.243 L 445.634 440.832 L 447.034 441.268" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 349.383 106.215 L 344.822 97.325 L 346.811 109.418" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1bbff" d="M 545.841 416.194 L 447.511 440.811 L 447.508 440.85" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e57fff" d="M 649.379 320.977 L 629.196 358.557 L 629.564 367.365" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 387.11 81.807 L 390.101 93.764 L 393.052 94.594" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ecffa1" d="M 535.893 304.1 L 522.576 295.667 L 518.728 346.991" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 445.823 441.325 L 445.93 441.349" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffca79" d="M 622.054 374.301 L 619.829 376.356 L 608.757 396.941 L 610.069 405.534" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 346.811 109.418 L 342.373 100.492 L 344.3 112.611" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#baffff" d="M 511.668 451.138 L 447.173 441.217 L 507.749 455.521" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c4dbff" d="M 445.706 441.285 L 368.709 461.876 L 374.755 464.246" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.586 440.869 L 445.559 440.902" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdfaf" d="M 574.02 429.654 L 580.509 423.419 L 534.049 439.36" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6eff4a" d="M 324.67 140.241 L 310.45 143.644 L 310.87 170.068" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6ddff" d="M 368.709 461.876 L 331.92 462.883 L 340.91 466.305" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#86ff67" d="M 302.843 210.999 L 279.577 216.127 L 303.357 246.622" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa5a5" d="M 592.642 315.746 L 563.272 355.505 L 572.266 360.5" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e167ff" d="M 632.304 278.377 L 621.513 276.659 L 621.55 277.014 L 621.448 290.832 L 620.256 293.774 L 635.706 313.032" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeaca" d="M 348.807 425.844 L 303.102 415.922 L 351.634 430.312" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9dfff" d="M 313.986 446.567 L 301.385 442.16 L 299.441 447.915 L 331.97 448.594" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc46a" d="M 240.78 265.453 L 246.088 226.625 L 225.788 275.416" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d8ff3e" d="M 432.821 111.948 L 386.832 103.029 L 417.951 116.138" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 387.11 81.807 L 384.487 81.491 L 390.101 93.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 446.616 440.524 L 446.483 440.53 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7ddff" d="M 422.066 386.747 L 393.316 353.894 L 413.501 391.194" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8888" d="M 228.977 356.98 L 228.862 356.829 L 228.875 357.913" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.499 440.78 L 447.469 440.747 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 397.213 96.043 L 399.019 102.929 L 403.92 104.033" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5a5a" d="M 520.564 155.077 L 501.15 158.629 L 508.95 167.578 L 559.161 193.592" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d0ffc4" d="M 381.826 399.424 L 374.417 403.129 L 445.909 440.664" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 341.576 118.396 L 339.758 110.274 L 341.194 119.754" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#418dff" d="M 408.248 177.393 L 417.199 212.022 L 442.407 224.088" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb4b4" d="M 264.742 395.886 L 249.211 379.826 L 238.5 387.382 L 278.301 402.968" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c6b8ff" d="M 477.181 459.684 L 446.79 441.337 L 471.167 464.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffbe" d="M 425.417 469.806 L 446.186 441.39 L 415.68 471.418" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#78ff56" d="M 302.843 210.999 L 291.705 174.508 L 279.577 216.127" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#2c80ff" d="M 388.006 118.38 L 397.003 141.235 L 416.331 151.216" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bad5ff" d="M 374.922 313.549 L 345.724 284.516 L 363.934 328.642" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3586ff" d="M 416.331 151.216 L 397.003 141.235 L 431.751 189.086" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdda9" d="M 569.01 410.123 L 529.745 426.534 L 536.824 430.847" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eeffa9" d="M 503.159 293.891 L 478.74 247.868 L 479.748 298.983" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 340.169 104.601 L 339.872 106.909 L 342.038 116.753" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c5" d="M 351.634 430.312 L 360.052 434.565 L 445.543 440.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa4a4" d="M 564.652 379.869 L 572.862 368.83 L 525.503 407.235" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbebe" d="M 313.986 446.567 L 331.97 448.594 L 357.257 450.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e167ff" d="M 620.256 293.774 L 613.8 309.715 L 635.706 313.032" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d1ffc6" d="M 374.417 403.129 L 371.391 408.346 L 445.85 440.69" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1ffb8" d="M 497.762 393.456 L 494.504 387.01 L 447.094 440.558" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdfb0" d="M 574.02 429.654 L 534.049 439.36 L 525.036 442.912" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bed8ff" d="M 443.161 385.956 L 432.266 384.932 L 446.483 440.53" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff3636" d="M 478.861 128.824 L 520.564 155.077 L 539.651 156.747" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#9affff" d="M 558.677 435.724 L 539.988 447.2 L 533.931 453.637" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6fa9ff" d="M 417.199 212.022 L 391.352 208.892 L 425.253 251.242" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7ffb9" d="M 362.256 364.358 L 314.115 331.754 L 345.185 367.316" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 368.185 82.762 L 365.501 83.491 L 370.741 94.728" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dbff4b" d="M 538.028 215.233 L 543.624 254.227 L 549.804 272.168" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 368.607 104.24 L 364.905 96.755 L 365.209 106.978" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2bdff" d="M 538.219 408.847 L 525.503 407.235 L 447.469 440.747" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#99c2ff" d="M 433.48 301.697 L 439.083 345.243 L 455.549 351.841" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe2b8" d="M 276.204 370.392 L 231.374 344.706 L 261.88 378.247" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 446.631 441.37 L 445.634 440.832 L 446.54 441.377" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 407.506 101.794 L 405.823 99.946 L 407.916 102.419" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe3ba" d="M 538.114 435.234 L 536.824 430.847 L 447.464 441.006" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9b9b" d="M 249.211 379.826 L 235.63 365.782 L 230.533 359.039 L 228.875 357.913 L 238.5 387.382" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbcbc" d="M 512.74 391.501 L 523.342 357.604 L 497.762 393.456" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9ffa8" d="M 273.473 298.164 L 258.523 276.995 L 268.836 311.743" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.555 441.161 L 445.608 441.208" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd89f" d="M 601.615 413.51 L 610.069 405.534 L 574.02 429.654" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c7ddff" d="M 445.608 441.208 L 369.444 452.084 L 366.741 457.787" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeaca" d="M 258.122 386.998 L 264.742 395.886 L 298.277 409.059" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5dcff" d="M 331.92 462.883 L 315.057 459.529 L 340.91 466.305" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 266.816 429.901 L 280.71 434.928 L 302.961 442.575" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d8ff3a" d="M 520.216 180.502 L 505.437 169.584 L 538.028 215.233" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bed8ff" d="M 384.382 464.764 L 374.755 464.246 L 354.879 467.049" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dcff4f" d="M 505.437 169.584 L 484.149 167.282 L 522.322 203.95" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d8ff3a" d="M 505.437 169.584 L 522.322 203.95 L 538.028 215.233" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eca1ff" d="M 592.93 348.584 L 564.652 379.869 L 583.811 382.436" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcf87" d="M 275.282 327.88 L 236.885 302.197 L 247.219 335.266" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ccffc0" d="M 362.256 364.358 L 345.185 367.316 L 393.057 397.599" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e784ff" d="M 649.379 320.977 L 635.706 313.032 L 629.196 358.557" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 303.102 415.922 L 281.171 404.467 L 266.375 414.11 L 316.164 422.405" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b9ffa8" d="M 263.034 262.432 L 258.523 276.995 L 273.473 298.164" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#227aff" d="M 381.915 106.207 L 377.315 103.755 L 402.262 125.902" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 447.094 440.558 L 446.985 440.535 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 402.504 87.934 L 405.823 99.946 L 407.506 101.794" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#accdff" d="M 455.549 351.841 L 439.083 345.243 L 453.779 389.946" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9a9a" d="M 604.048 333.794 L 603.832 322.537 L 572.862 368.83" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c2dbff" d="M 446.318 440.549 L 413.501 391.194 L 446.232 440.57" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbe0ff" d="M 328.631 456.945 L 303.865 455.294 L 331.92 462.883" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.48 440.966 L 445.634 440.832 L 447.464 441.006" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d6ffcb" d="M 371.391 408.346 L 333.63 391.695 L 373.213 414.699" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ccbfff" d="M 446.631 441.37 L 446.54 441.377 L 454.562 469.687" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7eb2ff" d="M 362.377 179.728 L 344.849 192.704 L 367.65 214.434" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6eff4a" d="M 310.87 170.068 L 310.45 143.644 L 291.705 174.508" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc2" d="M 446.038 441.372 L 445.93 441.349 L 400.958 468.151" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ceffc2" d="M 300.575 339.792 L 268.836 311.743 L 296.045 350.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7db1ff" d="M 345.36 154.315 L 336.14 171.048 L 344.849 192.704" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffacac" d="M 572.862 368.83 L 572.266 360.5 L 530.39 400.36" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#93beff" d="M 425.253 251.242 L 399.961 248.332 L 433.48 301.697" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#deff59" d="M 484.149 167.282 L 438.03 138.247 L 458.713 173.88" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc5c5" d="M 445.555 441.161 L 445.524 441.127 L 357.257 450.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 351.329 104.101 L 347.33 94.149 L 349.383 106.215" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4ffff" d="M 537.33 440.151 L 525.036 442.912 L 511.428 445.587 L 511.668 451.138" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 374.115 94.29 L 368.185 82.762 L 370.741 94.728" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e2ff6e" d="M 549.804 272.168 L 543.624 254.227 L 541.426 318.603" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 349.165 114.4 L 351.329 104.101 L 349.383 106.215 L 349.156 114.407" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c5" d="M 445.586 440.869 L 348.807 425.844 L 445.559 440.902" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbbbb" d="M 529.625 395.229 L 447.318 440.622 L 447.361 440.652" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcaca" d="M 303.448 430.124 L 299.268 436.974 L 351.036 439.673" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 408.36 95.436 L 411.265 105.688 L 411.768 105.801" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 445.988 440.639 L 445.791 440.725 L 445.712 440.778" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffbf" d="M 477.899 382.556 L 446.838 440.517 L 446.908 440.522" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ccbfff" d="M 445.231 468.933 L 442.891 473.03 L 456.331 474.106" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc6c6" d="M 302.961 442.575 L 313.986 446.567 L 349.965 448.009" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff6767" d="M 559.161 193.592 L 529.555 198.711 L 531.091 201.707 L 579.699 228.729" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 389.998 82.629 L 387.11 81.807 L 393.052 94.594" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eaff94" d="M 478.74 247.868 L 442.407 224.088 L 449.836 262.461" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c5dcff" d="M 391.422 303.502 L 374.922 313.549 L 406.365 346.556" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 394.071 84.065 L 389.998 82.629 L 397.213 96.043" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8989" d="M 608.867 268.643 L 592.642 315.746 L 603.832 322.537" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1bbff" d="M 545.016 411.96 L 447.499 440.78 L 447.511 440.811" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efffb0" d="M 522.576 295.667 L 503.159 293.891 L 508.232 340.868" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 398.104 85.531 L 394.071 84.065 L 401.332 97.522" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 446.038 441.372 L 446.115 441.385" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 362.572 110.713 L 356.173 100.976 L 356.863 110.965 L 362.236 111.189" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7ffff" d="M 511.428 445.587 L 447.231 441.182 L 511.668 451.138" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 384.063 93.524 L 379.088 93.889 L 386.832 103.029" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb7c" d="M 236.885 302.197 L 225.788 275.416 L 220.912 312.301" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 340.693 120.8 L 339.865 115.835 L 340.619 120.856" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc1" d="M 445.634 440.832 L 445.543 440.941 L 445.529 440.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 340.913 102.687 L 340.169 104.601 L 342.803 114.824" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa7a7" d="M 238.5 387.382 L 224.293 368.862 L 233.824 397.642" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bdffff" d="M 447.034 441.268 L 446.913 441.303 L 489.97 460.004" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#7aff58" d="M 291.705 174.508 L 301.493 150.535 L 279.83 183.461" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff3a3a" d="M 582.402 195.538 L 604.694 230.732 L 617.679 239.726" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd494" d="M 590.184 398.761 L 586.089 401.824 L 569.01 410.123 L 579.1 416.74" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dc4fff" d="M 620.69 268.737 L 621.513 276.659 L 632.304 278.377" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8cff70" d="M 303.357 246.622 L 313.246 283.434 L 345.724 284.516" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbe0ff" d="M 413.501 391.194 L 384.371 365.01 L 407.44 398.001" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffddaa" d="M 220.912 312.301 L 217.267 323.509 L 231.374 344.706" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d4ffc9" d="M 296.045 350.941 L 301.122 364.267 L 330.179 381.638" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3887ff" d="M 373.713 116.446 L 368.607 104.24 L 360.694 119.875" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 447.415 440.699 L 447.361 440.652 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 401.332 97.522 L 404.985 104.273 L 408.713 105.113" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc0" d="M 477.899 382.556 L 475.029 343.271 L 466.296 384.769" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8383" d="M 229.39 357.527 L 228.977 356.98 L 228.875 357.913" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ceffc1" d="M 393.057 397.599 L 381.826 399.424 L 445.988 440.639" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#5eff36" d="M 350.192 128.247 L 362.236 111.189 L 356.863 110.965 L 343.312 140.991" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c0ffff" d="M 446.913 441.303 L 477.181 459.684 L 489.97 460.004" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffeacb" d="M 261.88 378.247 L 258.122 386.998 L 301.749 402.342" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 447.231 441.182 L 445.634 440.832 L 447.173 441.217" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#71aaff" d="M 350.192 128.247 L 343.312 140.991 L 345.36 154.315" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f1ffba" d="M 436.001 465.948 L 446.275 441.389 L 425.417 469.806" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#6fff4b" d="M 310.87 170.068 L 302.843 210.999 L 333.632 212.131" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#4690ff" d="M 377.465 138.657 L 360.694 119.875 L 359.65 143.223" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 402.504 87.934 L 400.699 86.67 L 405.823 99.946" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#a4ff8e" d="M 313.246 283.434 L 335.697 327.761 L 363.934 328.642" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1daff" d="M 445.754 441.306 L 374.755 464.246 L 384.382 464.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#3f8cff" d="M 397.003 141.235 L 377.465 138.657 L 408.248 177.393" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 374.115 94.29 L 370.741 94.728 L 377.315 103.755" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#eea8ff" d="M 586.089 401.824 L 540.725 421.173 L 529.745 426.534" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efffae" d="M 479.748 298.983 L 449.836 262.461 L 454.677 310.745" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dc4fff" d="M 619.592 258.153 L 620.69 268.737 L 632.304 278.377" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc5c5" d="M 360.052 434.565 L 351.036 439.673 L 445.529 440.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cce0ff" d="M 369.444 452.084 L 331.97 448.594 L 328.631 456.945" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 353.958 88.954 L 351.204 90.503 L 356.173 100.976" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffadad" d="M 571.359 314.237 L 546.61 354.398 L 563.272 355.505" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 342.038 116.753 L 339.872 106.909 L 341.608 118.283" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d2ffc7" d="M 371.391 408.346 L 373.213 414.699 L 445.791 440.725" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 512.74 391.501 L 497.762 393.456 L 447.201 440.582" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe9c7" d="M 303.102 415.922 L 316.164 422.405 L 351.634 430.312" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 446.392 440.537 L 446.318 440.549 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bad6ff" d="M 453.779 389.946 L 443.161 385.956 L 446.616 440.524" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f2ffc0" d="M 407.334 470.86 L 388.397 475.778 L 400.425 476.573" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e5ff7d" d="M 471.753 208.392 L 431.751 189.086 L 442.407 224.088" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d83cff" d="M 622.754 250.398 L 618.51 247.729 L 619.144 253.835 L 646.273 286.892" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 398.104 85.531 L 401.332 97.522 L 403.982 98.672" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc46a" d="M 258.793 217.764 L 246.088 226.625 L 240.78 265.453" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#deff5a" d="M 522.322 203.95 L 528.319 243.739 L 543.624 254.227" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#accdff" d="M 411.644 299.356 L 422.14 343.542 L 439.083 345.243" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 365.501 83.491 L 362.485 84.771 L 367.994 95.464" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c4" d="M 261.88 378.247 L 227.619 355.183 L 258.122 386.998" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc062" d="M 265.328 226.43 L 269.358 214.49 L 258.793 217.764 L 262.618 235.525" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe3b9" d="M 536.824 430.847 L 529.745 426.534 L 447.48 440.966" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 390.101 93.764 L 387.419 93.445 L 395.556 102.149" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e9ff8f" d="M 535.893 304.1 L 518.728 346.991 L 523.342 357.604" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c9ffbb" d="M 288.625 288.333 L 273.473 298.164 L 314.115 331.754" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8888" d="M 228.875 357.913 L 228.862 356.829 L 227.619 355.183 L 226.32 351.21 L 224.293 368.862" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 340.766 120.745 L 339.692 113.609 L 339.865 115.835 L 340.693 120.8" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 407.506 101.794 L 407.916 102.419 L 408.543 103.161" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#bcffff" d="M 447.173 441.217 L 447.114 441.243 L 507.749 455.521" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cdc1ff" d="M 445.634 440.832 L 445.663 441.255 L 445.706 441.285" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 341.115 120.481 L 342.038 116.753 L 340.955 120.602" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cadfff" d="M 368.709 461.876 L 366.741 457.787 L 331.92 462.883" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#efb2ff" d="M 583.811 382.436 L 564.652 379.869 L 538.219 408.847" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#79ff57" d="M 302.843 210.999 L 303.357 246.622 L 336.488 247.784" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f4ffc6" d="M 400.958 468.151 L 379.058 471.912 L 388.397 475.778" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8d8d" d="M 604.048 333.794 L 572.862 368.83 L 564.652 379.869" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd79b" d="M 247.219 335.266 L 220.912 312.301 L 231.374 344.706" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c6" d="M 359.691 417.663 L 301.749 402.342 L 351.516 421.506" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcbcb" d="M 266.375 414.11 L 261.786 422.819 L 303.448 430.124" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 381.206 81.569 L 376.343 81.93 L 384.063 93.524" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#8ab9ff" d="M 391.352 208.892 L 367.65 214.434 L 399.961 248.332" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3c1ff" d="M 446.908 440.522 L 446.838 440.517 L 445.634 440.832" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#b7d4ff" d="M 439.083 345.243 L 422.14 343.542 L 443.161 385.956" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e57fff" d="M 649.471 331.618 L 649.379 320.977 L 629.564 367.365" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d1ffc6" d="M 345.185 367.316 L 300.575 339.792 L 334.223 373.293" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe6c1" d="M 447.508 440.85 L 445.634 440.832 L 447.495 440.908" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 372.76 103.129 L 367.994 95.464 L 368.607 104.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#d5ffcb" d="M 374.417 403.129 L 330.179 381.638 L 371.391 408.346" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe8c4" d="M 231.374 344.706 L 227.619 355.183 L 261.88 378.247" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff5050" d="M 478.861 128.824 L 470.052 130.503 L 475.925 134.599 L 486.29 142.378 L 520.564 155.077" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#edffa6" d="M 523.342 357.604 L 518.728 346.991 L 497.762 393.456" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#cbbeff" d="M 446.705 441.358 L 446.631 441.37 L 463.41 468.347" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#c1ffff" d="M 446.79 441.337 L 445.634 440.832 L 446.705 441.358" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#f3ffc2" d="M 446.115 441.385 L 446.038 441.372 L 407.334 470.86" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#86ff68" d="M 279.577 216.127 L 279.83 183.461 L 265.328 226.43" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#dbff4c" d="M 458.559 132.647 L 417.951 116.138 L 438.03 138.247" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 358.199 86.853 L 353.958 88.954 L 360.517 98.856" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#accdff" d="M 399.961 248.332 L 376.674 253.484 L 411.644 299.356" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#e2ff6f" d="M 458.713 173.88 L 416.331 151.216 L 431.751 189.086" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffffff" d="M 356.173 100.976 L 351.204 90.503 L 353.354 102.538" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdfaf" d="M 580.509 423.419 L 538.114 435.234 L 534.049 439.36" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffceb8" d="M 392.07 81.111 L 390.183 79.282 L 388.694 82.258 L 389.998 82.629 L 390.639 82.855" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 368.054 71.392 L 364.534 60.118 L 363.085 60.234 L 356.314 72.319" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb595" d="M 388.323 66.639 L 386.546 64.236 L 390.183 79.282" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa67f" d="M 360.35 53.477 L 359.338 48.738 L 345.306 61.125" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 377.172 55.657 L 361.264 56.935 L 362.322 60.295" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd4c1" d="M 345.306 61.125 L 336.572 72.751 L 339.2 74.737" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 361.264 56.935 L 347.321 63.992 L 348.208 64.599 L 349.503 64.193 L 350.57 64.858 L 350.674 66.128" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9c71" d="M 348.024 69.669 L 348.02 69.616 L 344.88 73.799" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9c71" d="M 350.701 66.152 L 350.677 66.164 L 350.679 66.182" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 346.864 94.739 L 346.27 95.208 L 346.48 95.226" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9568" d="M 376.457 47.351 L 359.338 48.738 L 360.35 53.477" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd1bd" d="M 390.931 70.164 L 390.183 79.282 L 392.07 81.111" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb190" d="M 344.359 56.396 L 346.521 55.291 L 343.318 38.85 L 339.864 62.418" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9d72" d="M 349.228 92.053 L 349.741 91.651 L 349.569 89.461 L 343.394 84.906 L 349.187 92.099" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff986c" d="M 344.88 73.799 L 343.684 75.265 L 344.596 82.844" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 347.321 63.992 L 339.2 74.737 L 343.684 75.265" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 363.085 60.234 L 362.322 60.295 L 360.722 61.101 L 356.314 72.319" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb190" d="M 382.506 81.538 L 381.1 77.251 L 382.094 81.548" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb190" d="M 384.793 62.543 L 382.181 61.589 L 380.072 64.252 L 384.068 76.246" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffceb8" d="M 390.183 79.282 L 387.931 82.041 L 388.694 82.258" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 342.883 91.764 L 342.904 93.188 L 344.247 94.839 L 346.27 95.208" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 340.038 88.872 L 336.299 85.07 L 340.048 89.677" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd7c6" d="M 336.572 72.751 L 336.299 85.07 L 338.914 86.145" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa67f" d="M 359.338 48.738 L 344.359 56.396 L 345.306 61.125" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 377.172 55.657 L 376.756 56.669 L 377.761 57.314 L 378.48 59.472 L 390.5 60.547" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 346.48 95.226 L 346.27 95.208 L 346.445 95.269" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcdb7" d="M 386.934 63.325 L 385.509 62.805 L 392.89 71.387" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb595" d="M 338.638 64.062 L 335.884 49.016 L 337.608 65.441" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa57f" d="M 371.482 82.328 L 375.042 82.037 L 378.11 68.135 L 377.621 66.643 L 368.054 71.392 L 370.458 82.463" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 349.187 92.099 L 343.394 84.906 L 342.787 85.074 L 342.836 88.515 L 349.038 92.263" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 340.005 85.902 L 340.025 85.838 L 338.914 86.145 L 340.015 86.81" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8450" d="M 375.836 47.401 L 383.01 35.595 L 370.722 30.978 L 374.553 47.505" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff783e" d="M 349.084 83.245 L 346.795 71.283 L 345.85 72.524 L 344.596 82.844 L 349.533 88.998" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfa3" d="M 377.535 52.092 L 360.35 53.477 L 361.264 56.935" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa57f" d="M 347.628 54.725 L 356.106 32.183 L 343.318 38.85 L 346.521 55.291" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 377.621 66.643 L 377.15 65.208 L 369.369 59.731 L 366.492 59.961 L 368.054 71.392" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcdb7" d="M 385.509 62.805 L 385.478 62.793 L 390.931 70.164 L 392.89 71.387" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 375.2 59.264 L 371.453 59.564 L 376.998 64.746" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 382.181 61.589 L 378.77 60.343 L 380.072 64.252" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 360.722 61.101 L 350.701 66.152 L 350.679 66.182 L 351.028 70.431 L 356.314 72.319" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8450" d="M 356.314 72.319 L 351.028 70.431 L 352.198 84.646" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8450" d="M 348.024 69.669 L 346.795 71.283 L 349.084 83.245" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb190" d="M 344.359 56.396 L 335.67 68.039 L 336.572 72.751" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8450" d="M 383.01 35.595 L 375.836 47.401 L 376.457 47.351 L 386.849 51.197" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa67f" d="M 399.49 67.775 L 397.525 70.136 L 397.846 74.05 L 398.736 76.039" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb696" d="M 336.572 72.751 L 335.67 68.039 L 336.299 85.07" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcab3" d="M 346.267 95.495 L 344.247 94.839 L 346.239 95.53" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9567" d="M 362.485 84.771 L 363.777 84.223 L 368.054 71.392 L 356.314 72.319 L 359.164 86.384" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 392.07 81.111 L 390.639 82.855 L 391.321 83.095" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 366.492 59.961 L 364.534 60.118 L 368.054 71.392" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 390.5 60.547 L 378.48 59.472 L 378.77 60.343 L 386.934 63.325" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 340.025 85.838 L 340.346 84.839 L 341.738 84.411 L 342.786 85.047 L 342.787 85.074 L 343.394 84.906 L 339.2 74.737 L 338.914 86.145" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd4c1" d="M 347.321 63.992 L 345.306 61.125 L 339.2 74.737" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8550" d="M 376.457 47.351 L 377.535 52.092 L 390.8 52.659" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa67f" d="M 397.566 80.836 L 396.737 78.963 L 396.496 81.659" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa67f" d="M 397.525 70.136 L 397.287 72.799 L 397.846 74.05" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 390.5 60.547 L 386.934 63.325 L 397.525 70.136" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa984" d="M 396.496 81.659 L 394.408 84.188 L 394.545 84.237" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9d72" d="M 349.533 88.998 L 344.596 82.844 L 343.394 84.906 L 349.569 89.461" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8450" d="M 353.958 88.954 L 358.199 86.853 L 359.164 86.384 L 356.314 72.319 L 352.198 84.646 L 352.615 89.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb190" d="M 390.183 79.282 L 386.546 64.236 L 385.478 62.793 L 384.793 62.543 L 384.068 76.246 L 385.87 81.657 L 387.11 81.807 L 387.931 82.041" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 348.016 69.574 L 347.718 65.752 L 348.076 64.64 L 348.208 64.599 L 347.321 63.992 L 343.684 75.265" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 342.872 91.022 L 342.883 91.764 L 346.27 95.208" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 340.023 87.511 L 338.914 86.145 L 336.299 85.07 L 340.038 88.872" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd7c6" d="M 339.2 74.737 L 336.572 72.751 L 338.914 86.145" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9567" d="M 374.553 47.505 L 370.722 30.978 L 360.804 48.619" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8550" d="M 390.8 52.659 L 377.535 52.092 L 391.927 57.393" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff783e" d="M 389.547 44.66 L 387.911 51.59 L 390.8 52.659 L 391.961 54.258" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 393.439 71.239 L 393.794 70.29 L 395.235 69.848 L 396.231 70.485 L 397.525 70.136 L 386.934 63.325 L 392.89 71.387" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa57f" d="M 376.343 81.93 L 381.206 81.569 L 382.094 81.548 L 381.1 77.251 L 378.11 68.135 L 375.042 82.037" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 376.998 64.746 L 371.453 59.564 L 369.369 59.731 L 377.15 65.208" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9567" d="M 360.804 48.619 L 370.722 30.978 L 356.106 32.183 L 359.624 48.715" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9c71" d="M 344.88 73.799 L 348.02 69.616 L 348.016 69.574 L 343.684 75.265" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa57f" d="M 359.338 48.738 L 359.624 48.715 L 356.106 32.183 L 347.628 54.725" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9568" d="M 377.535 52.092 L 376.457 47.351 L 360.35 53.477" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb190" d="M 339.864 62.418 L 343.318 38.85 L 335.884 49.016 L 338.638 64.062" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 396.737 78.963 L 393.383 71.388 L 393.439 71.239 L 392.89 71.387 L 396.496 81.659" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 397.525 70.136 L 396.231 70.485 L 396.262 70.505 L 397.287 72.799" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff986c" d="M 344.596 82.844 L 343.684 75.265 L 343.394 84.906" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 362.322 60.295 L 361.264 56.935 L 350.674 66.128 L 350.677 66.164" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb190" d="M 345.306 61.125 L 344.359 56.396 L 336.572 72.751" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff783e" d="M 389.547 44.66 L 383.01 35.595 L 386.849 51.197 L 387.911 51.59" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb292" d="M 377.535 52.092 L 377.172 55.657 L 391.927 57.393" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd1bd" d="M 392.89 71.387 L 390.931 70.164 L 392.07 81.111" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcab3" d="M 346.445 95.269 L 346.27 95.208 L 344.247 94.839 L 346.267 95.495" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff9567" d="M 365.501 83.491 L 368.185 82.762 L 370.458 82.463 L 368.054 71.392 L 363.777 84.223" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb595" d="M 337.608 65.441 L 335.884 49.016 L 335.659 59.829 L 336.853 66.453" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff783f" d="M 390.8 52.659 L 391.927 57.393 L 398.348 63.055" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 392.89 71.387 L 392.07 81.111 L 396.496 81.659" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 346.864 94.739 L 347.33 94.149 L 349.038 92.263 L 342.836 88.515 L 342.872 91.022 L 346.27 95.208" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 340.015 86.81 L 338.914 86.145 L 340.023 87.511" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c0" d="M 343.684 75.265 L 339.2 74.737 L 343.394 84.906" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa985" d="M 391.927 57.393 L 390.5 60.547 L 399.49 67.775" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff783e" d="M 345.85 72.524 L 344.88 73.799 L 344.596 82.844" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb292" d="M 391.927 57.393 L 377.172 55.657 L 390.5 60.547" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa984" d="M 397.666 81.062 L 397.566 80.836 L 396.496 81.659 L 394.545 84.237 L 394.927 84.376" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb595" d="M 390.931 70.164 L 388.323 66.639 L 390.183 79.282" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcbb5" d="M 360.35 53.477 L 345.306 61.125 L 347.321 63.992" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 375.2 59.264 L 374.859 58.223 L 375.254 57.093 L 376.706 56.637 L 376.756 56.669 L 377.172 55.657 L 362.322 60.295" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff783f" d="M 398.348 63.055 L 391.927 57.393 L 399.49 67.775" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd3c1" d="M 396.496 81.659 L 392.07 81.111 L 391.321 83.095 L 394.071 84.065 L 394.408 84.188" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfa3" d="M 377.172 55.657 L 377.535 52.092 L 361.264 56.935" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb696" d="M 335.67 68.039 L 335.41 80.376 L 336.299 85.07" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcbb5" d="M 361.264 56.935 L 360.35 53.477 L 347.321 63.992" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa985" d="M 399.49 67.775 L 390.5 60.547 L 397.525 70.136" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 112.021 183.918 L 112.049 184.044 L 112.411 184.141" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd66e" d="M 109.743 142.111 L 103.791 143.13 L 106.065 182.446 L 106.144 182.468" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 56.81 272.935 L 60.098 271.316 L 60.178 270.688 L 52.677 273.898" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 60.178 270.688 L 62.973 248.58 L 34.635 231.065 L 52.677 273.898" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc739" d="M 140.738 234.354 L 121.81 169.528 L 120.384 188.963 L 122.342 190.524 L 124.313 197.425 L 120.815 203.747 L 119.34 204.627 L 139.662 234.442" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd873" d="M 18.499 201.617 L 20.829 201.415 L 23.682 163.578 L 16.6 202.676" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 86.192 201.345 L 85.518 200.768 L 83.522 194.846 L 42.042 205.509 L 43.391 206.484" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc739" d="M 45.706 221.586 L 44.178 222.437 L 44.654 228.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc737" d="M 122.858 149.578 L 119.972 188.636 L 120.34 188.929" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffde89" d="M 94.929 183.069 L 98.728 145.504 L 95.702 148.636 L 94.691 183.09" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc737" d="M 158.602 202.002 L 157.375 239.988 L 157.926 240.415" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc739" d="M 68.205 207.204 L 67.469 207.385 L 67.965 209.101" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 34.635 231.065 L 19.267 234.941 L 52.677 273.898" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffca44" d="M 115.404 143.034 L 112.021 183.918 L 112.411 184.141 L 115.304 184.913 L 117.303 186.507" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc83b" d="M 156.298 199.477 L 154.953 238.112 L 157.24 239.884" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc839" d="M 122.858 149.578 L 120.462 146.087 L 119.867 188.551 L 119.972 188.636" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 127.852 253.512 L 124.315 250.395 L 124.247 250.174 L 119.6 255.143 L 121.272 255.55 L 121.948 256.044" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdb7e" d="M 125.507 239.24 L 117.333 227.763 L 117.242 228.999 L 125.362 239.488" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcf53" d="M 152.688 197.495 L 148.266 196.477 L 150.995 236.04 L 151.194 236.091" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc739" d="M 67.965 209.101 L 67.469 207.385 L 57.846 209.754 L 55.605 226.118 L 64.399 237.308" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd362" d="M 25.858 200.979 L 32.471 162.477 L 27.899 162.445 L 25.604 201.001" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd058" d="M 109.743 142.111 L 106.144 182.468 L 110.958 183.753 L 112.021 183.918" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 125.804 238.733 L 133.488 234.948 L 138.375 234.548 L 109.776 210.335 L 106.369 212.369 L 125.507 239.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdb7e" d="M 123.374 247.327 L 122.478 244.405 L 125.362 239.488 L 117.242 228.999 L 115.642 250.728" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdc81" d="M 16.6 202.676 L 23.682 163.578 L 20.398 165.64 L 16.468 202.749" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb44" d="M 152.688 197.495 L 151.194 236.091 L 152.901 236.522 L 154.794 237.989" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 64.399 237.308 L 55.605 226.118 L 44.654 228.709 L 63.483 244.548" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdb7c" d="M 100.01 182.622 L 103.791 143.13 L 98.728 145.504 L 99.836 182.637" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcd4d" d="M 32.471 162.477 L 25.858 200.979 L 28.773 200.726 L 30.228 201.096" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc839" d="M 120.462 146.087 L 117.354 186.548 L 119.867 188.551" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 87.491 202.457 L 86.192 201.345 L 43.391 206.484 L 46.441 208.689 L 47.822 212.221" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd873" d="M 83.522 194.846 L 83.212 193.927 L 85.356 189.626 L 40.346 166.925 L 34.618 202.212 L 39.037 203.336 L 42.042 205.509" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd058" d="M 115.404 143.034 L 109.743 142.111 L 112.021 183.918" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 63.483 244.548 L 44.654 228.709 L 34.635 231.065 L 62.973 248.58" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd873" d="M 55.605 226.118 L 53.6 210.799 L 47.822 212.221 L 49.018 215.276 L 46.196 221.313 L 45.706 221.586 L 44.654 228.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffca44" d="M 120.462 146.087 L 115.404 143.034 L 117.303 186.507 L 117.354 186.548" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd362" d="M 25.604 201.001 L 27.899 162.445 L 21.013 201.399" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 41.005 224.205 L 38.569 225.562 L 44.654 228.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdb7c" d="M 99.836 182.637 L 98.728 145.504 L 94.929 183.069" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd568" d="M 148.266 196.477 L 143.544 196.843 L 146.36 234.869 L 146.597 234.929" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 139.662 234.442 L 119.34 204.627 L 109.776 210.335 L 138.375 234.548" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcd4d" d="M 36.815 163.9 L 32.471 162.477 L 30.228 201.096 L 30.598 201.19" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd873" d="M 86.444 187.443 L 91.972 184.452 L 95.344 152.072 L 40.346 166.925 L 85.356 189.626" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc93d" d="M 40.346 166.925 L 36.815 163.9 L 34.127 202.087 L 34.618 202.212" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc83b" d="M 158.602 202.002 L 156.298 199.477 L 157.24 239.884 L 157.375 239.988" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 124.247 250.174 L 123.374 247.327 L 115.642 250.728 L 115.393 254.118 L 119.6 255.143" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdc81" d="M 16.468 202.749 L 20.398 165.64 L 13.225 204.557" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe08f" d="M 13.225 204.557 L 20.398 165.64 L 19.474 167.65 L 13.196 204.573" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc737" d="M 159.123 204.655 L 158.602 202.002 L 157.926 240.415 L 157.989 240.464" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 112.021 183.918 L 110.958 183.753 L 112.049 184.044" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc739" d="M 141.733 234.272 L 143.544 196.843 L 122.235 163.741 L 121.81 169.528 L 140.738 234.354" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc93d" d="M 36.815 163.9 L 30.598 201.19 L 34.127 202.087" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd568" d="M 143.544 196.843 L 141.733 234.272 L 143.446 234.132 L 146.36 234.869" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe08f" d="M 13.196 204.573 L 19.474 167.65 L 12.583 204.914" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc737" d="M 123.023 153.004 L 122.858 149.578 L 120.34 188.929 L 120.384 188.963" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc739" d="M 44.178 222.437 L 41.005 224.205 L 44.654 228.709" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffedc1" d="M 44.654 228.709 L 38.569 225.562 L 32.794 228.78 L 34.635 231.065" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd873" d="M 57.846 209.754 L 53.6 210.799 L 55.605 226.118" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffde89" d="M 94.449 183.112 L 94.691 183.09 L 95.702 148.636 L 91.972 184.452" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd873" d="M 21.013 201.399 L 27.899 162.445 L 23.682 163.578 L 20.829 201.415" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd66e" d="M 105.058 182.178 L 106.065 182.446 L 103.791 143.13 L 100.01 182.622" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd874" d="M 34.635 231.065 L 32.794 228.78 L 27.535 231.71 L 26.858 232.07 L 25.932 232.147 L 25.003 231.921 L 24.32 231.451 L 20.527 227.633 L 19.267 234.941" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcf53" d="M 148.266 196.477 L 146.597 234.929 L 150.995 236.04" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb44" d="M 156.298 199.477 L 152.688 197.495 L 154.794 237.989 L 154.953 238.112" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb47" d="M 352.615 89.709 L 350.57 64.858 L 349.503 64.193 L 352.549 89.746" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd66c" d="M 351.204 90.503 L 351.577 90.293 L 348.076 64.64 L 350.176 91.309" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdf8b" d="M 350.175 91.31 L 347.718 65.752 L 349.741 91.651" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffdf8b" d="M 350.176 91.309 L 348.076 64.64 L 347.718 65.752 L 350.175 91.31" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd66c" d="M 351.612 90.273 L 349.503 64.193 L 348.076 64.64 L 351.577 90.293" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb47" d="M 352.549 89.746 L 349.503 64.193 L 351.612 90.273" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 159.233 241.428 L 141.86 262.317 L 142.444 262.748" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 141.003 262.108 L 143.446 234.132 L 140.102 262.179" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 125.804 238.733 L 122.478 244.405 L 139.087 263.013" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 160.775 247.467 L 142.444 262.748 L 142.598 263.287" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 142.444 262.748 L 141.86 262.317 L 140.843 263.15" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 141.582 264.118 L 140.843 263.15 L 140.684 264.188" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 140.102 262.179 L 133.488 234.948 L 139.401 262.511" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7f7f" d="M 159.233 241.428 L 152.901 236.522 L 141.86 262.317" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 152.901 236.522 L 143.446 234.132 L 141.003 262.108" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 141.86 262.317 L 141.003 262.108 L 140.843 263.15" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 140.843 263.15 L 139.828 263.981 L 140.684 264.188" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 140.102 262.179 L 139.401 262.511 L 140.843 263.15" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 142.598 263.287 L 140.843 263.15 L 142.282 263.788" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 122.478 244.405 L 124.315 250.395 L 139.244 263.551" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 140.843 263.15 L 139.087 263.013 L 139.244 263.551" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffa0a0" d="M 143.446 234.132 L 133.488 234.948 L 140.102 262.179" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 141.003 262.108 L 140.102 262.179 L 140.843 263.15" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 142.282 263.788 L 140.843 263.15 L 141.582 264.118" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 139.401 262.511 L 139.087 263.013 L 140.843 263.15" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 157.223 253.006 L 142.598 263.287 L 142.282 263.788" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc3c3" d="M 139.087 263.013 L 122.478 244.405 L 139.244 263.551" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7a7a" d="M 160.775 247.467 L 159.233 241.428 L 142.444 262.748" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffb2b2" d="M 133.488 234.948 L 125.804 238.733 L 139.401 262.511" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 140.843 263.15 L 139.244 263.551 L 139.828 263.981" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc1c1" d="M 142.444 262.748 L 140.843 263.15 L 142.598 263.287" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff7d7d" d="M 157.223 253.006 L 160.775 247.467 L 142.598 263.287" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ff8e8e" d="M 152.901 236.522 L 141.003 262.108 L 141.86 262.317" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffbfbf" d="M 139.401 262.511 L 125.804 238.733 L 139.087 263.013" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe194" d="M 60.262 271.235 L 68.354 207.167 L 68.233 207.197 L 60.249 271.242" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb44" d="M 112.011 220.29 L 106.369 212.369 L 105.572 212.845 L 107.349 271.89 L 107.871 272.258" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd15a" d="M 92.724 206.937 L 88.168 203.037 L 81.472 266.152 L 86.809 265.731 L 95.595 267.817" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffde87" d="M 67.89 267.478 L 70.356 206.675 L 68.354 207.167 L 60.262 271.235" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc738" d="M 114.283 223.48 L 112.011 220.29 L 107.871 272.258 L 113.295 276.076" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffc738" d="M 117.333 227.763 L 114.283 223.48 L 113.295 276.076 L 113.753 276.399" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd772" d="M 81.472 266.152 L 88.168 203.037 L 87.491 202.457 L 79.608 204.397 L 81.021 266.188" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffde87" d="M 68.306 267.274 L 75.667 205.367 L 70.356 206.675 L 67.89 267.478" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd15a" d="M 101.008 213.981 L 100.54 213.628 L 92.724 206.937 L 95.595 267.817 L 96.067 267.929" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffe194" d="M 60.249 271.242 L 68.233 207.197 L 68.205 207.204 L 60.098 271.316" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffcb44" d="M 105.572 212.845 L 103.805 213.899 L 103.074 214.277 L 102.118 214.357 L 101.191 214.12 L 101.008 213.981 L 96.067 267.929 L 104.602 269.956 L 107.349 271.89" transform="matrix(1,0,0,-1,0,478)"/>
+<path fill="#ffd772" d="M 68.504 267.176 L 81.021 266.188 L 79.608 204.397 L 75.667 205.367 L 68.306 267.274" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 407.69 92.14 C 407.69 93.095 406.915 93.87 405.96 93.87 C 405.005 93.87 404.23 93.095 404.23 92.14 C 404.23 91.185 405.005 90.41 405.96 90.41 C 406.915 90.41 407.69 91.185 407.69 92.14" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 401.073 86.38 C 401.073 86.961 400.601 87.433 400.02 87.433 C 399.439 87.433 398.967 86.961 398.967 86.38 C 398.967 85.799 399.439 85.327 400.02 85.327 C 400.601 85.327 401.073 85.799 401.073 86.38" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 399.055 86.799 L 397.933 84.279 L 396.788 81.759 L 395.637 79.234 L 394.497 76.705 L 393.366 74.177 L 392.347 70.736 L 395.63 68.563 L 398.595 70.973 L 399.847 73.654 L 400.966 76.184 L 402.064 78.724 L 403.149 81.269 L 404.227 83.815 L 405.306 86.357 L 406.394 88.889 L 407.504 91.409 L 404.34 92.813 L 403.213 90.293 L 402.081 87.769 L 400.949 85.247 L 399.815 82.731 L 398.676 80.224 L 397.531 77.729 L 396.377 75.248 L 395.316 72.954 L 395.082 71.168 L 394.353 71.768 L 395.323 73.371 L 396.364 75.882 L 397.491 78.391 L 398.655 80.901 L 399.827 83.417 L 400.974 85.934" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 344.562 99.7 C 344.562 100.584 343.844 101.302 342.96 101.302 C 342.076 101.302 341.358 100.584 341.358 99.7 C 341.358 98.816 342.076 98.098 342.96 98.098 C 343.844 98.098 344.562 98.816 344.562 99.7" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 341.381 104.44 C 341.381 105.092 340.852 105.621 340.2 105.621 C 339.548 105.621 339.019 105.092 339.019 104.44 C 339.019 103.788 339.548 103.259 340.2 103.259 C 340.852 103.259 341.381 103.788 341.381 104.44" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 339.035 104.492 L 339.01 102.171 L 338.981 99.85 L 338.949 97.527 L 338.917 95.202 L 338.885 92.875 L 338.855 90.549 L 338.828 88.222 L 338.803 85.312 L 341.485 83.132 L 344.427 84.99 L 344.799 87.937 L 344.792 90.294 L 344.736 92.655 L 344.662 95.01 L 344.604 97.347 L 344.599 99.671 L 341.395 99.689 L 341.363 97.348 L 341.329 94.992 L 341.284 92.65 L 341.214 90.338 L 341.108 88.072 L 341.249 86.472 L 341.4 85.699 L 341.206 86.495 L 341.17 88.219 L 341.166 90.531 L 341.185 92.847 L 341.22 95.166 L 341.265 97.487 L 341.314 99.811 L 341.359 102.137 L 341.397 104.461" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 28.742 231.76 C 28.742 232.424 28.204 232.962 27.54 232.962 C 26.876 232.962 26.338 232.424 26.338 231.76 C 26.338 231.096 26.876 230.558 27.54 230.558 C 28.204 230.558 28.742 231.096 28.742 231.76" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 25.12 231.46 C 25.12 231.913 24.753 232.28 24.3 232.28 C 23.847 232.28 23.48 231.913 23.48 231.46 C 23.48 231.007 23.847 230.64 24.3 230.64 C 24.753 230.64 25.12 231.007 25.12 231.46" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 23.739 232.03 L 21.367 229.69 L 18.947 227.382 L 16.52 225.06 L 14.136 222.695 L 11.809 220.266 L 9.515 217.647 L 7.674 214.365 L 7.231 210.759 L 8.48 207.025 L 10.761 204.115 L 13.757 201.992 L 17.087 200.494 L 20.465 199.586 L 23.972 199.109 L 27.496 199.022 L 30.954 199.302 L 34.422 199.946 L 37.813 200.949 L 41.043 202.322 L 44.17 204.186 L 46.993 206.549 L 49.254 209.522 L 50.686 213.287 L 50.671 217.148 L 48.996 220.972 L 46.218 223.52 L 43.268 225.337 L 40.26 226.917 L 37.189 228.381 L 34.107 229.796 L 31.068 231.229 L 28.11 232.766 L 26.978 230.644 L 29.927 229.03 L 32.913 227.421 L 35.871 225.809 L 38.749 224.161 L 41.498 222.45 L 44.008 220.699 L 45.973 218.862 L 46.99 216.381 L 47.008 213.955 L 45.99 211.331 L 44.306 209.088 L 42.036 207.142 L 39.391 205.491 L 36.593 204.225 L 33.584 203.256 L 30.473 202.596 L 27.363 202.263 L 24.183 202.259 L 21.031 202.603 L 18.053 203.319 L 15.162 204.532 L 12.676 206.175 L 10.911 208.355 L 9.959 211.066 L 10.168 213.681 L 11.339 216.543 L 13.124 219.159 L 15.275 221.601 L 17.61 223.941 L 20.033 226.236 L 22.482 228.531 L 24.885 230.857" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 27.776 232.12 C 27.776 232.648 27.348 233.076 26.82 233.076 C 26.292 233.076 25.864 232.648 25.864 232.12 C 25.864 231.592 26.292 231.164 26.82 231.164 C 27.348 231.164 27.776 231.592 27.776 232.12" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 27.776 232.12 C 27.776 232.647 27.347 233.076 26.82 233.076 C 26.293 233.076 25.864 232.647 25.864 232.12 C 25.864 231.593 26.293 231.164 26.82 231.164 C 27.347 231.164 27.776 231.593 27.776 232.12" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 26.141 232.703 L 25.039 229.907 L 27.575 231.437 L 26.143 232.703 L 24.936 229.999 L 27.574 231.438" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 85.862 320.68 C 85.862 321.344 85.324 321.882 84.66 321.882 C 83.996 321.882 83.458 321.344 83.458 320.68 C 83.458 320.016 83.996 319.478 84.66 319.478 C 85.324 319.478 85.862 320.016 85.862 320.68" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 79.78 320.2 C 79.78 320.653 79.413 321.02 78.96 321.02 C 78.507 321.02 78.14 320.653 78.14 320.2 C 78.14 319.747 78.507 319.38 78.96 319.38 C 79.413 319.38 79.78 319.747 79.78 320.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 78.365 320.805 L 76.369 318.704 L 74.352 316.621 L 72.317 314.545 L 70.272 312.473 L 68.224 310.4 L 66.18 308.322 L 64.147 306.234 L 62.133 304.132 L 60.145 302.01 L 58.189 299.865 L 56.274 297.691 L 54.384 295.491 L 52.497 293.215 L 50.711 290.616 L 49.292 287.754 L 48.544 284.737 L 48.734 281.723 L 49.776 278.675 L 51.411 275.821 L 53.431 273.371 L 55.7 271.438 L 58.227 269.77 L 60.945 268.332 L 63.778 267.122 L 66.65 266.142 L 69.502 265.387 L 72.411 264.803 L 75.372 264.374 L 78.363 264.097 L 81.362 263.966 L 84.345 263.979 L 87.289 264.131 L 90.234 264.425 L 93.194 264.865 L 96.146 265.45 L 99.067 266.183 L 101.932 267.065 L 104.72 268.098 L 107.449 269.31 L 110.164 270.763 L 112.788 272.445 L 115.243 274.345 L 117.457 276.468 L 119.358 278.899 L 120.889 281.851 L 121.892 285.073 L 122.202 288.341 L 121.633 291.448 L 120.248 294.429 L 118.317 297.126 L 116.107 299.427 L 113.847 301.363 L 111.576 303.194 L 109.263 304.97 L 106.913 306.702 L 104.534 308.396 L 102.134 310.062 L 99.721 311.708 L 97.301 313.341 L 94.881 314.97 L 92.471 316.602 L 90.075 318.247 L 87.703 319.91 L 85.362 321.614 L 83.937 319.677 L 86.269 317.941 L 88.615 316.205 L 90.968 314.477 L 93.322 312.754 L 95.671 311.03 L 98.01 309.3 L 100.332 307.562 L 102.63 305.811 L 104.9 304.042 L 107.135 302.252 L 109.329 300.435 L 111.476 298.59 L 113.514 296.75 L 115.369 294.719 L 116.936 292.488 L 118.021 290.266 L 118.441 288.171 L 118.198 285.819 L 117.41 283.271 L 116.211 280.903 L 114.698 278.943 L 112.828 277.119 L 110.67 275.41 L 108.319 273.86 L 105.862 272.499 L 103.371 271.348 L 100.793 270.352 L 98.119 269.488 L 95.378 268.758 L 92.597 268.164 L 89.802 267.706 L 87.018 267.386 L 84.231 267.201 L 81.401 267.147 L 78.554 267.229 L 75.715 267.451 L 72.91 267.817 L 70.165 268.329 L 67.493 268.997 L 64.812 269.871 L 62.175 270.955 L 59.669 272.239 L 57.384 273.708 L 55.415 275.338 L 53.708 277.405 L 52.335 279.833 L 51.474 282.294 L 51.253 284.56 L 51.698 286.985 L 52.683 289.595 L 54.066 292.141 L 55.701 294.436 L 57.495 296.648 L 59.37 298.815 L 61.296 300.95 L 63.265 303.06 L 65.269 305.149 L 67.299 307.224 L 69.346 309.289 L 71.403 311.351 L 73.46 313.415 L 75.511 315.487 L 77.545 317.573 L 79.552 319.674" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 84.296 321.22 C 84.296 321.747 83.868 322.176 83.34 322.176 C 82.812 322.176 82.384 321.747 82.384 321.22 C 82.384 320.692 82.812 320.264 83.34 320.264 C 83.868 320.264 84.296 320.692 84.296 321.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 84.296 321.22 C 84.296 321.747 83.867 322.176 83.34 322.176 C 82.813 322.176 82.384 321.747 82.384 321.22 C 82.384 320.693 82.813 320.264 83.34 320.264 C 83.867 320.264 84.296 320.693 84.296 321.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 83.249 322.164 L 79.012 320.919 L 80.035 317.301 L 84.806 318.143 L 84.297 321.514 L 82.48 320.922 L 83.759 318.809 L 80.673 318.517 L 79.903 320.382 L 83.522 320.273" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 124.346 15.94 C 124.346 17.014 123.474 17.886 122.4 17.886 C 121.326 17.886 120.454 17.014 120.454 15.94 C 120.454 14.866 121.326 13.994 122.4 13.994 C 123.474 13.994 124.346 14.866 124.346 15.94" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 81.714 23.14 C 81.714 24.031 80.991 24.754 80.1 24.754 C 79.209 24.754 78.486 24.031 78.486 23.14 C 78.486 22.249 79.209 21.526 80.1 21.526 C 80.991 21.526 81.714 22.249 81.714 23.14" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 78.921 22.007 L 81.257 19.491 L 83.531 16.874 L 85.833 14.212 L 88.222 11.602 L 90.762 9.139 L 93.51 6.933 L 96.544 5.024 L 100.002 3.314 L 103.692 2.038 L 107.429 1.5 L 110.945 2.075 L 114.057 3.847 L 116.752 6.366 L 119.189 9.22 L 121.493 12.059 L 123.828 14.646 L 120.925 17.237 L 118.544 14.541 L 116.26 11.59 L 114.064 8.839 L 111.903 6.63 L 109.765 5.242 L 107.384 4.823 L 104.463 5.243 L 101.254 6.333 L 98.123 7.861 L 95.378 9.566 L 92.89 11.554 L 90.53 13.843 L 88.239 16.35 L 85.966 18.983 L 83.657 21.645 L 81.288 24.203" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 81.998 23.08 C 81.998 24.128 81.148 24.978 80.1 24.978 C 79.052 24.978 78.202 24.128 78.202 23.08 C 78.202 22.032 79.052 21.182 80.1 21.182 C 81.148 21.182 81.998 22.032 81.998 23.08" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 47.088 35.98 C 47.088 36.834 46.395 37.528 45.54 37.528 C 44.685 37.528 43.992 36.834 43.992 35.98 C 43.992 35.125 44.685 34.432 45.54 34.432 C 46.395 34.432 47.088 35.125 47.088 35.98" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 44.025 35.763 L 44.487 32.526 L 44.788 29.144 L 45.149 25.695 L 45.799 22.335 L 47.02 19.211 L 49.127 16.578 L 52.224 14.537 L 55.808 13.217 L 59.442 12.751 L 62.764 13.192 L 65.946 14.149 L 69.048 15.44 L 72.087 16.931 L 75.069 18.496 L 77.991 20.012 L 80.914 21.395 L 79.277 24.819 L 76.296 23.38 L 73.319 21.771 L 70.401 20.155 L 67.539 18.657 L 64.734 17.396 L 62.001 16.487 L 59.393 16.043 L 56.548 16.362 L 53.621 17.379 L 51.193 18.886 L 49.674 20.745 L 48.754 23.18 L 48.194 26.143 L 47.858 29.439 L 47.556 32.879 L 47.09 36.197" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 124.137 15.94 C 124.137 16.899 123.359 17.677 122.4 17.677 C 121.441 17.677 120.663 16.899 120.663 15.94 C 120.663 14.981 121.441 14.203 122.4 14.203 C 123.359 14.203 124.137 14.981 124.137 15.94" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 152.593 42.82 C 152.593 43.92 151.7 44.813 150.6 44.813 C 149.5 44.813 148.607 43.92 148.607 42.82 C 148.607 41.72 149.5 40.827 150.6 40.827 C 151.7 40.827 152.593 41.72 152.593 42.82" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 148.644 42.695 L 148.905 39.286 L 149.325 35.826 L 149.718 32.472 L 149.919 29.295 L 149.78 26.373 L 149.166 23.737 L 147.864 21.067 L 145.984 18.508 L 143.828 16.52 L 141.617 15.444 L 139.087 15.118 L 136.144 15.25 L 132.924 15.738 L 129.531 16.424 L 126.055 17.13 L 122.658 17.66 L 122.112 14.229 L 125.417 13.692 L 128.792 12.947 L 132.255 12.172 L 135.747 11.567 L 139.228 11.35 L 142.687 11.794 L 145.966 13.304 L 148.884 15.868 L 151.238 19.019 L 152.888 22.406 L 153.71 25.809 L 153.904 29.314 L 153.694 32.827 L 153.288 36.3 L 152.873 39.681 L 152.618 42.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 47.366 35.98 C 47.366 36.988 46.548 37.806 45.54 37.806 C 44.532 37.806 43.714 36.988 43.714 35.98 C 43.714 34.972 44.532 34.154 45.54 34.154 C 46.548 34.154 47.366 34.972 47.366 35.98" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 18.962 102.34 C 18.962 102.904 18.504 103.362 17.94 103.362 C 17.376 103.362 16.918 102.904 16.918 102.34 C 16.918 101.776 17.376 101.318 17.94 101.318 C 18.504 101.318 18.962 101.776 18.962 102.34" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 16.924 102.492 L 16.597 99.356 L 16.269 96.22 L 15.943 93.084 L 15.615 89.948 L 15.288 86.812 L 14.962 83.676 L 14.635 80.54 L 13.981 74.268 L 13.655 71.133 L 13.32 68.013 L 12.874 64.841 L 12.33 61.596 L 11.735 58.307 L 11.141 55.008 L 10.596 51.728 L 10.151 48.499 L 9.858 45.347 L 9.769 42.298 L 9.933 39.345 L 10.675 36.37 L 13.145 34.081 L 16.678 32.727 L 20.33 32.057 L 23.56 31.834 L 26.771 31.876 L 29.98 32.107 L 33.178 32.47 L 36.359 32.911 L 39.515 33.374 L 42.639 33.808 L 45.76 34.17 L 45.333 37.798 L 42.172 37.421 L 38.993 36.964 L 35.838 36.483 L 32.714 36.027 L 29.629 35.644 L 26.59 35.378 L 23.603 35.272 L 20.646 35.355 L 17.342 35.694 L 14.342 36.407 L 12.466 37.584 L 11.956 39.666 L 11.745 42.34 L 11.805 45.234 L 12.079 48.277 L 12.518 51.433 L 13.07 54.668 L 13.682 57.95 L 14.301 61.246 L 14.872 64.527 L 15.342 67.76 L 15.687 70.917 L 16.015 74.056 L 16.342 77.192 L 16.669 80.328 L 16.996 83.464 L 17.322 86.6 L 18.957 102.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 14.563 54.34 C 14.563 55.258 13.818 56.003 12.9 56.003 C 11.982 56.003 11.237 55.258 11.237 54.34 C 11.237 53.422 11.982 52.677 12.9 52.677 C 13.818 52.677 14.563 53.422 14.563 54.34" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 11.68 127.42 C 11.68 127.972 11.232 128.42 10.68 128.42 C 10.128 128.42 9.68 127.972 9.68 127.42 C 9.68 126.868 10.128 126.42 10.68 126.42 C 11.232 126.42 11.68 126.868 11.68 127.42" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 9.72 127.497 L 9.462 124.995 L 9.207 122.492 L 8.953 119.99 L 8.7 117.488 L 8.446 114.986 L 8.191 112.485 L 7.933 109.985 L 7.672 107.486 L 7.405 104.988 L 7.133 102.491 L 6.854 99.997 L 6.56 97.507 L 6.249 95.019 L 5.917 92.534 L 5.564 90.054 L 5.181 87.592 L 4.691 85.095 L 4.112 82.548 L 3.478 79.967 L 2.828 77.37 L 2.198 74.776 L 1.626 72.2 L 1.151 69.66 L .809 67.169 L .643 64.74 L .692 62.377 L 1.079 59.947 L 2.482 57.831 L 4.748 56.252 L 7.358 55.034 L 9.925 53.962 L 12.218 52.831 L 13.63 55.842 L 11.176 56.938 L 8.438 57.831 L 5.94 58.671 L 4.047 59.597 L 2.994 60.788 L 2.684 62.574 L 2.592 64.71 L 2.719 66.982 L 3.029 69.36 L 3.485 71.82 L 4.048 74.343 L 4.68 76.909 L 5.342 79.5 L 5.994 82.098 L 6.596 84.688 L 7.108 87.25 L 7.504 89.764 L 7.863 92.263 L 8.205 94.762 L 8.529 97.264 L 8.834 99.767 L 9.12 102.27 L 9.395 104.773 L 9.663 107.275 L 9.926 109.778 L 10.184 112.281 L 10.439 114.784 L 10.692 117.286 L 10.944 119.788 L 11.197 122.29 L 11.452 124.791 L 11.71 127.292" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 123.883 15.94 C 123.883 16.758 123.218 17.423 122.4 17.423 C 121.582 17.423 120.917 16.758 120.917 15.94 C 120.917 15.122 121.582 14.457 122.4 14.457 C 123.218 14.457 123.883 15.122 123.883 15.94" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 112.353 140.2 C 112.353 140.98 111.72 141.613 110.94 141.613 C 110.16 141.613 109.527 140.98 109.527 140.2 C 109.527 139.42 110.16 138.787 110.94 138.787 C 111.72 138.787 112.353 139.42 112.353 140.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 109.549 140.281 L 109.373 136.349 L 109.197 132.416 L 109.021 128.484 L 108.845 124.551 L 108.668 120.618 L 108.49 116.686 L 108.312 112.753 L 108.132 108.832 L 107.891 104.925 L 107.561 101.006 L 107.197 97.063 L 106.857 93.103 L 106.599 89.128 L 106.48 85.145 L 106.561 81.157 L 106.895 77.185 L 107.456 73.246 L 108.195 69.339 L 109.068 65.459 L 110.033 61.604 L 111.048 57.768 L 112.07 53.948 L 113.06 50.141 L 113.978 46.334 L 114.843 42.506 L 115.712 38.666 L 117.452 30.988 L 119.194 23.31 L 120.063 19.471 L 120.931 15.631 L 123.824 16.284 L 122.958 20.124 L 122.094 23.965 L 120.368 31.646 L 119.506 35.487 L 117.778 43.168 L 116.908 47.019 L 115.976 50.874 L 114.971 54.716 L 113.937 58.541 L 112.918 62.351 L 111.955 66.15 L 111.087 69.943 L 110.357 73.732 L 109.803 77.519 L 109.472 81.314 L 109.383 85.136 L 109.486 88.996 L 109.725 92.891 L 110.049 96.814 L 110.399 100.76 L 110.721 104.722 L 110.957 108.683 L 111.132 112.626 L 111.307 116.559 L 111.484 120.492 L 111.661 124.424 L 111.838 128.357 L 112.016 132.289 L 112.372 140.155" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 81.42 23.08 C 81.42 23.808 80.828 24.399 80.1 24.399 C 79.372 24.399 78.78 23.808 78.78 23.08 C 78.78 22.352 79.372 21.76 80.1 21.76 C 80.828 21.76 81.42 22.352 81.42 23.08" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 63.279 145.36 C 63.279 146.077 62.697 146.659 61.98 146.659 C 61.263 146.659 60.681 146.077 60.681 145.36 C 60.681 144.643 61.263 144.061 61.98 144.061 C 62.697 144.061 63.279 144.643 63.279 145.36" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 60.702 145.008 L 61.645 141.244 L 62.588 137.481 L 63.53 133.717 L 66.359 122.425 L 67.303 118.662 L 68.249 114.893 L 69.231 111.121 L 70.28 107.36 L 71.353 103.616 L 72.412 99.882 L 73.416 96.154 L 74.327 92.424 L 75.108 88.689 L 75.721 84.935 L 76.166 81.151 L 76.475 77.336 L 76.68 73.494 L 76.811 69.632 L 76.899 65.752 L 76.975 61.861 L 77.069 57.961 L 77.214 54.064 L 77.408 50.18 L 77.604 46.305 L 77.799 42.43 L 77.995 38.555 L 78.192 34.679 L 78.388 30.804 L 78.585 26.929 L 78.782 23.054 L 81.418 23.189 L 81.219 27.064 L 81.021 30.939 L 80.822 34.814 L 80.622 38.689 L 80.423 42.564 L 80.223 46.439 L 80.024 50.313 L 79.825 54.179 L 79.676 58.043 L 79.575 61.92 L 79.492 65.809 L 79.395 69.707 L 79.254 73.609 L 79.038 77.51 L 78.715 81.406 L 78.255 85.291 L 77.622 89.156 L 76.823 92.989 L 75.899 96.79 L 74.89 100.565 L 73.833 104.32 L 72.768 108.061 L 71.734 111.794 L 70.764 115.535 L 69.824 119.293 L 68.881 123.057 L 67.939 126.821 L 66.995 130.585 L 66.052 134.349 L 65.109 138.112 L 64.165 141.876 L 63.222 145.64" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 112.013 140.2 C 112.013 140.792 111.533 141.273 110.94 141.273 C 110.348 141.273 109.867 140.792 109.867 140.2 C 109.867 139.607 110.348 139.127 110.94 139.127 C 111.533 139.127 112.013 139.607 112.013 140.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 62.81 145.3 C 62.81 145.791 62.411 146.19 61.92 146.19 C 61.429 146.19 61.03 145.791 61.03 145.3 C 61.03 144.809 61.429 144.41 61.92 144.41 C 62.411 144.41 62.81 144.809 62.81 145.3" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 61.564 144.539 L 64.45 143.089 L 67.315 141.553 L 70.216 140.029 L 73.185 138.629 L 76.249 137.472 L 79.39 136.602 L 82.593 135.857 L 85.851 135.248 L 89.139 134.799 L 92.428 134.541 L 95.7 134.5 L 98.963 134.778 L 102.176 135.611 L 105.29 136.791 L 108.322 138.069 L 111.344 139.228 L 110.569 141.23 L 107.518 140.038 L 104.501 138.714 L 101.544 137.525 L 98.616 136.698 L 95.62 136.406 L 92.505 136.415 L 89.33 136.641 L 86.137 137.054 L 82.959 137.63 L 79.829 138.342 L 76.799 139.166 L 73.876 140.261 L 71.006 141.614 L 68.147 143.118 L 65.269 144.665 L 62.364 146.129" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 46.769 35.98 C 46.769 36.658 46.218 37.209 45.54 37.209 C 44.862 37.209 44.311 36.658 44.311 35.98 C 44.311 35.302 44.862 34.751 45.54 34.751 C 46.218 34.751 46.769 35.302 46.769 35.98" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 37.621 155.5 C 37.621 156.13 37.11 156.641 36.48 156.641 C 35.85 156.641 35.339 156.13 35.339 155.5 C 35.339 154.87 35.85 154.358 36.48 154.358 C 37.11 154.358 37.621 154.87 37.621 155.5" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 35.341 155.361 L 35.771 151.638 L 36.202 147.915 L 36.632 144.191 L 37.063 140.468 L 37.493 136.745 L 37.923 133.021 L 38.352 129.298 L 38.781 125.573 L 39.217 121.845 L 39.68 118.118 L 40.155 114.396 L 40.629 110.679 L 41.087 106.965 L 41.515 103.252 L 41.897 99.542 L 42.22 95.83 L 42.471 92.115 L 42.659 88.391 L 42.797 84.66 L 42.899 80.923 L 42.979 77.179 L 43.053 73.43 L 43.133 69.678 L 43.235 65.923 L 43.364 62.173 L 43.499 58.427 L 43.637 54.681 L 43.776 50.936 L 43.916 47.19 L 44.056 43.445 L 44.193 39.699 L 44.328 35.953 L 46.784 36.04 L 46.653 39.786 L 46.525 43.532 L 46.273 51.024 L 46.146 54.77 L 46.019 58.516 L 45.888 62.262 L 45.757 66.003 L 45.645 69.743 L 45.548 73.488 L 45.452 77.238 L 45.345 80.991 L 45.214 84.747 L 45.049 88.504 L 44.835 92.261 L 44.561 96.017 L 44.22 99.766 L 43.822 103.508 L 43.383 107.241 L 42.915 110.968 L 42.434 114.689 L 41.954 118.406 L 41.488 122.12 L 41.049 125.837 L 40.618 129.559 L 40.187 133.283 L 39.757 137.006 L 39.327 140.73 L 38.897 144.453 L 38.468 148.176 L 38.038 151.9 L 37.609 155.623" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 63.029 145.36 C 63.029 145.939 62.559 146.409 61.98 146.409 C 61.401 146.409 60.931 145.939 60.931 145.36 C 60.931 144.781 61.401 144.311 61.98 144.311 C 62.559 144.311 63.029 144.781 63.029 145.36" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 37.277 155.5 C 37.277 155.94 36.92 156.297 36.48 156.297 C 36.04 156.297 35.683 155.94 35.683 155.5 C 35.683 155.06 36.04 154.703 36.48 154.703 C 36.92 154.703 37.277 155.06 37.277 155.5" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 35.688 155.374 L 36.035 153.243 L 36.287 150.993 L 36.767 148.767 L 37.797 146.86 L 39.355 145.359 L 41.173 144.047 L 43.192 142.922 L 45.325 142.039 L 47.491 141.457 L 49.625 141.244 L 51.78 141.402 L 53.925 141.835 L 56.049 142.437 L 58.145 143.112 L 60.198 143.766 L 62.237 144.325 L 61.674 146.346 L 59.594 145.757 L 57.502 145.047 L 55.449 144.33 L 53.444 143.7 L 51.498 143.245 L 49.624 143.05 L 47.789 143.191 L 45.864 143.672 L 43.912 144.443 L 42.048 145.445 L 40.381 146.613 L 39.049 147.827 L 38.241 149.309 L 37.847 151.242 L 37.606 153.456 L 37.261 155.628" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 111.931 140.26 C 111.931 140.807 111.487 141.251 110.94 141.251 C 110.393 141.251 109.949 140.807 109.949 140.26 C 109.949 139.713 110.393 139.269 110.94 139.269 C 111.487 139.269 111.931 139.713 111.931 140.26" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 133.586 160.72 C 133.586 161.364 133.064 161.886 132.42 161.886 C 131.776 161.886 131.254 161.364 131.254 160.72 C 131.254 160.076 131.776 159.554 132.42 159.554 C 133.064 159.554 133.586 160.076 133.586 160.72" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 131.31 161.099 L 130.625 159.083 L 129.989 157.041 L 129.359 155.035 L 128.679 153.095 L 127.9 151.251 L 126.956 149.486 L 125.885 147.676 L 124.72 145.892 L 123.47 144.255 L 122.147 142.872 L 120.786 141.838 L 119.287 141.241 L 117.476 141.037 L 115.389 141.076 L 113.161 141.2 L 110.981 141.222 L 110.948 139.24 L 113.071 139.191 L 115.274 138.992 L 117.54 138.863 L 119.801 139.049 L 121.892 139.801 L 123.703 141.091 L 125.273 142.707 L 126.657 144.528 L 127.889 146.439 L 128.998 148.345 L 130.004 150.249 L 130.853 152.256 L 131.57 154.299 L 132.214 156.345 L 132.842 158.361 L 133.519 160.348" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 152.214 42.82 C 152.214 43.711 151.491 44.434 150.6 44.434 C 149.709 44.434 148.986 43.711 148.986 42.82 C 148.986 41.929 149.709 41.206 150.6 41.206 C 151.491 41.206 152.214 41.929 152.214 42.82" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 133.998 160.72 C 133.998 161.591 133.291 162.298 132.42 162.298 C 131.549 162.298 130.842 161.591 130.842 160.72 C 130.842 159.849 131.549 159.142 132.42 159.142 C 133.291 159.142 133.998 159.849 133.998 160.72" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 130.906 160.265 L 135.19 145.869 L 136.26 142.27 L 137.331 138.671 L 138.405 135.063 L 139.526 131.447 L 140.743 127.851 L 141.981 124.286 L 143.174 120.742 L 144.255 117.207 L 145.161 113.672 L 145.831 110.107 L 146.293 106.484 L 146.625 102.815 L 146.848 99.116 L 146.99 95.392 L 147.076 91.647 L 147.132 87.886 L 147.184 84.113 L 147.261 80.332 L 147.387 76.554 L 147.564 72.792 L 147.745 69.041 L 147.926 65.29 L 148.108 61.54 L 148.291 57.789 L 148.473 54.039 L 148.656 50.288 L 148.837 46.537 L 149.018 42.787 L 152.243 42.942 L 152.063 46.693 L 151.884 50.443 L 151.705 54.194 L 151.527 57.945 L 151.349 61.695 L 150.991 69.197 L 150.811 72.947 L 150.633 76.686 L 150.503 80.422 L 150.421 84.172 L 150.358 87.937 L 150.291 91.713 L 150.192 95.495 L 150.036 99.278 L 149.795 103.058 L 149.444 106.831 L 148.953 110.603 L 148.241 114.357 L 147.29 118.06 L 146.175 121.705 L 144.964 125.306 L 143.726 128.873 L 142.528 132.42 L 141.424 135.981 L 140.356 139.571 L 139.286 143.17 L 135.002 157.566 L 133.932 161.165" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 18.301 95.56 C 18.301 96.156 17.816 96.641 17.22 96.641 C 16.624 96.641 16.139 96.156 16.139 95.56 C 16.139 94.964 16.624 94.479 17.22 94.479 C 17.816 94.479 18.301 94.964 18.301 95.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 13.022 165.04 C 13.022 165.637 12.537 166.122 11.94 166.122 C 11.343 166.122 10.858 165.637 10.858 165.04 C 10.858 164.443 11.343 163.958 11.94 163.958 C 12.537 163.958 13.022 164.443 13.022 165.04" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 10.843 164.904 L 11.051 162.737 L 11.26 160.57 L 11.468 158.403 L 11.677 156.236 L 11.886 154.07 L 12.095 151.903 L 12.303 149.736 L 12.512 147.569 L 12.721 145.403 L 12.929 143.236 L 13.137 141.069 L 13.346 138.903 L 13.553 136.736 L 13.761 134.569 L 13.969 132.4 L 14.186 130.23 L 14.411 128.061 L 14.641 125.894 L 14.872 123.728 L 15.1 121.565 L 15.322 119.402 L 15.534 117.241 L 15.732 115.082 L 15.913 112.923 L 16.072 110.765 L 16.204 108.616 L 16.273 106.473 L 16.284 104.32 L 16.258 102.157 L 16.213 99.983 L 16.171 97.799 L 16.152 95.616 L 18.313 95.598 L 18.331 97.77 L 18.368 99.942 L 18.407 102.125 L 18.428 104.316 L 18.411 106.515 L 18.337 108.717 L 18.202 110.909 L 18.042 113.09 L 17.862 115.267 L 17.665 117.442 L 17.455 119.615 L 17.236 121.785 L 17.01 123.953 L 16.783 126.12 L 16.557 128.284 L 16.335 130.447 L 16.122 132.61 L 15.915 134.775 L 15.709 136.942 L 15.501 139.109 L 15.293 141.276 L 14.877 145.61 L 14.668 147.777 L 14.459 149.944 L 14.25 152.111 L 14.041 154.278 L 13.832 156.444 L 13.414 160.778 L 13.205 162.944 L 12.997 165.111" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 37.393 155.5 C 37.393 156.004 36.984 156.413 36.48 156.413 C 35.976 156.413 35.567 156.004 35.567 155.5 C 35.567 154.996 35.976 154.587 36.48 154.587 C 36.984 154.587 37.393 154.996 37.393 155.5" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 13.744 170.26 C 13.744 170.693 13.393 171.044 12.96 171.044 C 12.527 171.044 12.176 170.693 12.176 170.26 C 12.176 169.827 12.527 169.476 12.96 169.476 C 13.393 169.476 13.744 169.827 13.744 170.26" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 12.16 170.543 L 11.468 168.452 L 10.879 166.153 L 11.579 164.254 L 13.073 162.859 L 14.763 161.688 L 16.626 160.629 L 18.583 159.671 L 20.563 158.802 L 24.402 157.353 L 28.349 156.309 L 30.352 155.878 L 32.34 155.473 L 34.31 155.063 L 36.268 154.615 L 36.673 156.395 L 34.696 156.843 L 32.7 157.248 L 30.714 157.64 L 28.758 158.044 L 24.93 159.027 L 21.203 160.397 L 19.28 161.205 L 17.389 162.098 L 15.619 163.071 L 14.056 164.119 L 12.837 165.137 L 12.356 166.223 L 12.956 167.987 L 13.647 170.048" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 12.151 118.48 C 12.151 119.06 11.68 119.531 11.1 119.531 C 10.52 119.531 10.049 119.06 10.049 118.48 C 10.049 117.9 10.52 117.429 11.1 117.429 C 11.68 117.429 12.151 117.9 12.151 118.48" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 9.57 178.9 C 9.57 179.479 9.099 179.95 8.52 179.95 C 7.941 179.95 7.47 179.479 7.47 178.9 C 7.47 178.321 7.941 177.85 8.52 177.85 C 9.099 177.85 9.57 178.321 9.57 178.9" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 7.488 178.883 L 7.647 175.105 L 7.807 171.328 L 7.967 167.551 L 8.127 163.773 L 8.287 159.996 L 8.446 156.219 L 8.606 152.441 L 8.766 148.664 L 8.926 144.887 L 9.085 141.109 L 9.245 137.332 L 9.405 133.555 L 9.564 129.777 L 9.724 126 L 9.884 122.223 L 10.043 118.445 L 12.143 118.534 L 11.983 122.312 L 11.823 126.089 L 11.663 129.866 L 11.503 133.644 L 11.343 137.421 L 11.183 141.198 L 11.023 144.976 L 10.864 148.753 L 10.704 152.53 L 10.544 156.308 L 10.384 160.085 L 10.224 163.862 L 10.065 167.64 L 9.905 171.417 L 9.745 175.194 L 9.585 178.972" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 152.448 42.82 C 152.448 43.84 151.62 44.668 150.6 44.668 C 149.58 44.668 148.752 43.84 148.752 42.82 C 148.752 41.8 149.58 40.972 150.6 40.972 C 151.62 40.972 152.448 41.8 152.448 42.82" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 153.052 181.06 C 153.052 181.95 152.33 182.672 151.44 182.672 C 150.55 182.672 149.828 181.95 149.828 181.06 C 149.828 180.17 150.55 179.448 151.44 179.448 C 152.33 179.448 153.052 180.17 153.052 181.06" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 149.85 180.713 L 151.332 173.513 L 151.826 171.112 L 153.802 161.512 L 154.296 159.111 L 155.284 154.311 L 155.777 151.911 L 156.271 149.511 L 156.764 147.11 L 157.257 144.71 L 157.751 142.31 L 158.244 139.909 L 158.738 137.509 L 159.233 135.108 L 159.728 132.708 L 160.224 130.308 L 160.72 127.908 L 161.714 123.108 L 162.212 120.709 L 162.71 118.309 L 163.208 115.91 L 163.706 113.51 L 164.204 111.111 L 164.703 108.711 L 166.197 101.514 L 166.695 99.114 L 167.194 96.714 L 167.698 94.302 L 168.248 91.878 L 168.838 89.457 L 169.455 87.041 L 170.086 84.632 L 170.717 82.23 L 171.335 79.837 L 171.926 77.452 L 172.478 75.078 L 172.978 72.715 L 173.412 70.365 L 173.769 68.029 L 174.035 65.708 L 174.187 63.425 L 174.149 61.201 L 173.806 58.897 L 173.181 56.604 L 172.308 54.483 L 171.241 52.689 L 170.015 51.32 L 168.507 50.261 L 166.695 49.32 L 164.647 48.511 L 162.409 47.807 L 160.03 47.179 L 157.558 46.589 L 155.043 45.994 L 152.529 45.35 L 150.119 44.629 L 151.172 41.086 L 153.506 41.774 L 155.912 42.359 L 158.401 42.906 L 160.929 43.464 L 163.452 44.083 L 165.928 44.82 L 168.316 45.736 L 170.569 46.9 L 172.649 48.418 L 174.396 50.447 L 175.72 52.881 L 176.648 55.537 L 177.225 58.286 L 177.474 61.008 L 177.418 63.553 L 177.208 66.017 L 176.91 68.458 L 176.526 70.896 L 176.07 73.33 L 175.554 75.761 L 174.993 78.187 L 174.398 80.608 L 173.783 83.023 L 173.159 85.432 L 172.539 87.833 L 171.937 90.225 L 171.363 92.607 L 170.83 94.982 L 170.333 97.367 L 169.339 102.165 L 168.842 104.565 L 168.345 106.964 L 167.848 109.364 L 167.35 111.763 L 166.854 114.163 L 166.357 116.562 L 165.86 118.962 L 165.363 121.361 L 164.371 126.161 L 163.875 128.56 L 163.38 130.96 L 162.885 133.359 L 162.39 135.759 L 161.897 138.159 L 160.909 142.959 L 160.416 145.359 L 159.923 147.76 L 159.43 150.16 L 158.936 152.56 L 158.442 154.961 L 157.454 159.761 L 156.961 162.162 L 154.985 171.762 L 154.491 174.163 L 153.009 181.363" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 133.53 160.72 C 133.53 161.333 133.033 161.83 132.42 161.83 C 131.807 161.83 131.31 161.333 131.31 160.72 C 131.31 160.107 131.807 159.61 132.42 159.61 C 133.033 159.61 133.53 160.107 133.53 160.72" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 147.549 191.02 C 147.549 191.654 147.034 192.169 146.4 192.169 C 145.766 192.169 145.251 191.654 145.251 191.02 C 145.251 190.386 145.766 189.871 146.4 189.871 C 147.034 189.871 147.549 190.386 147.549 191.02" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 145.385 190.401 L 146.786 188.101 L 148.344 185.84 L 149.614 183.716 L 150.267 181.734 L 150.15 179.664 L 149.673 177.319 L 148.892 174.89 L 147.851 172.507 L 146.601 170.283 L 145.205 168.339 L 143.668 166.779 L 141.758 165.569 L 139.502 164.565 L 137.022 163.667 L 134.457 162.765 L 131.999 161.756 L 132.84 159.701 L 135.244 160.681 L 137.77 161.547 L 140.343 162.455 L 142.837 163.546 L 145.11 164.979 L 146.977 166.832 L 148.568 169.027 L 149.938 171.47 L 151.065 174.073 L 151.91 176.74 L 152.432 179.39 L 152.51 182.036 L 151.696 184.649 L 150.277 187.075 L 148.712 189.348 L 147.348 191.595" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 13.702 170.32 C 13.702 170.763 13.343 171.122 12.9 171.122 C 12.457 171.122 12.098 170.763 12.098 170.32 C 12.098 169.877 12.457 169.518 12.9 169.518 C 13.343 169.518 13.702 169.877 13.702 170.32" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 15.331 194.32 C 15.331 194.768 14.968 195.131 14.52 195.131 C 14.072 195.131 13.709 194.768 13.709 194.32 C 13.709 193.872 14.072 193.509 14.52 193.509 C 14.968 193.509 15.331 193.872 15.331 194.32" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 14.093 194.995 L 10.973 192.934 L 8.139 190.497 L 7.003 187.128 L 6.984 183.345 L 7.577 179.61 L 8.691 176.198 L 10.435 173.009 L 12.207 169.903 L 13.599 170.699 L 11.827 173.791 L 10.135 176.827 L 9.1 179.977 L 8.554 183.465 L 8.564 186.874 L 9.424 189.622 L 11.94 191.631 L 14.987 193.641" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 173.694 82.72 C 173.694 83.777 172.837 84.634 171.78 84.634 C 170.723 84.634 169.866 83.777 169.866 82.72 C 169.866 81.663 170.723 80.806 171.78 80.806 C 172.837 80.806 173.694 81.663 173.694 82.72" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 163.742 204.82 C 163.742 205.715 163.015 206.442 162.12 206.442 C 161.225 206.442 160.498 205.715 160.498 204.82 C 160.498 203.925 161.225 203.198 162.12 203.198 C 163.015 203.198 163.742 203.925 163.742 204.82" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 160.463 204.608 L 160.802 202.567 L 161.141 200.525 L 161.48 198.484 L 161.819 196.442 L 162.158 194.401 L 162.497 192.359 L 162.836 190.318 L 163.175 188.276 L 163.514 186.235 L 163.853 184.193 L 164.192 182.152 L 164.531 180.115 L 164.858 178.082 L 165.168 176.046 L 165.468 174.003 L 165.764 171.954 L 166.062 169.9 L 166.368 167.843 L 166.688 165.784 L 167.03 163.725 L 167.398 161.668 L 167.8 159.612 L 168.242 157.563 L 168.721 155.527 L 169.226 153.504 L 169.751 151.488 L 170.295 149.479 L 170.856 147.475 L 171.43 145.477 L 172.014 143.483 L 172.607 141.493 L 173.206 139.507 L 173.807 137.523 L 174.409 135.541 L 175.009 133.561 L 175.603 131.581 L 176.19 129.602 L 176.768 127.62 L 177.347 125.622 L 177.965 123.611 L 178.614 121.603 L 179.283 119.602 L 179.962 117.606 L 180.641 115.616 L 181.309 113.633 L 181.957 111.657 L 182.574 109.688 L 183.151 107.728 L 183.677 105.776 L 184.143 103.834 L 184.54 101.904 L 184.851 99.993 L 185.024 98.234 L 184.785 96.57 L 184.162 94.876 L 183.282 93.296 L 181.054 90.495 L 178.098 88.373 L 176.402 87.42 L 174.545 86.442 L 172.634 85.429 L 170.794 84.368 L 172.699 81.048 L 174.477 82.062 L 176.324 83.008 L 178.243 83.975 L 180.216 85.055 L 183.782 87.68 L 186.516 91.273 L 187.511 93.56 L 188.108 95.915 L 188.233 98.269 L 187.944 100.439 L 187.577 102.482 L 187.143 104.513 L 186.646 106.539 L 186.096 108.56 L 185.502 110.577 L 184.875 112.589 L 184.224 114.596 L 183.558 116.598 L 182.888 118.594 L 182.222 120.584 L 181.57 122.567 L 180.941 124.542 L 180.344 126.511 L 179.777 128.49 L 179.2 130.484 L 178.615 132.476 L 178.024 134.465 L 177.43 136.451 L 176.835 138.435 L 176.242 140.418 L 175.654 142.399 L 175.072 144.38 L 174.5 146.361 L 173.939 148.343 L 173.392 150.325 L 172.862 152.309 L 172.351 154.296 L 171.861 156.284 L 171.397 158.271 L 170.973 160.261 L 170.585 162.262 L 170.226 164.275 L 169.892 166.299 L 169.576 168.331 L 169.273 170.372 L 168.976 172.419 L 168.679 174.47 L 168.377 176.526 L 168.063 178.584 L 167.732 180.638 L 167.393 182.684 L 167.054 184.725 L 166.715 186.766 L 166.376 188.808 L 166.036 190.849 L 165.697 192.891 L 165.358 194.932 L 165.019 196.974 L 164.68 199.015 L 164.341 201.057 L 164.002 203.098 L 163.663 205.14" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 147.529 191.02 C 147.529 191.643 147.023 192.149 146.4 192.149 C 145.777 192.149 145.271 191.643 145.271 191.02 C 145.271 190.397 145.777 189.891 146.4 189.891 C 147.023 189.891 147.529 190.397 147.529 191.02" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 160.118 207.7 C 160.118 208.317 159.617 208.818 159 208.818 C 158.383 208.818 157.882 208.317 157.882 207.7 C 157.882 207.083 158.383 206.582 159 206.582 C 159.617 206.582 160.118 207.083 160.118 207.7" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 158.372 206.775 L 160.987 205.338 L 160.252 203.991 L 158.147 201.979 L 155.541 199.793 L 153.138 197.733 L 150.688 195.774 L 148.181 193.843 L 145.675 191.896 L 147.058 190.111 L 149.564 192.048 L 152.092 193.974 L 154.602 195.957 L 157.036 198.032 L 159.703 200.292 L 162.142 202.865 L 162.721 205.918 L 159.686 208.584" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 161.191 207.16 C 161.191 208.038 160.478 208.751 159.6 208.751 C 158.722 208.751 158.009 208.038 158.009 207.16 C 158.009 206.282 158.722 205.569 159.6 205.569 C 160.478 205.569 161.191 206.282 161.191 207.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 160.531 216.04 C 160.531 216.918 159.818 217.631 158.94 217.631 C 158.062 217.631 157.349 216.918 157.349 216.04 C 157.349 215.162 158.062 214.449 158.94 214.449 C 159.818 214.449 160.531 215.162 160.531 216.04" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 157.333 215.896 L 157.504 213.679 L 157.676 211.462 L 157.847 209.245 L 158.018 207.027 L 161.192 207.273 L 161.02 209.49 L 160.849 211.707 L 160.678 213.924 L 160.506 216.142" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 160.012 215.56 C 160.012 216.218 159.478 216.752 158.82 216.752 C 158.162 216.752 157.628 216.218 157.628 215.56 C 157.628 214.902 158.162 214.368 158.82 214.368 C 159.478 214.368 160.012 214.902 160.012 215.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 159.833 216.16 C 159.833 216.752 159.352 217.233 158.76 217.233 C 158.168 217.233 157.687 216.752 157.687 216.16 C 157.687 215.568 158.168 215.087 158.76 215.087 C 159.352 215.087 159.833 215.568 159.833 216.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 157.86 215.526 L 157.879 215.805 L 157.662 215.994 L 159.893 215.15 L 159.92 215.983 L 159.661 216.693" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 105.062 213.88 C 105.062 214.544 104.524 215.082 103.86 215.082 C 103.196 215.082 102.658 214.544 102.658 213.88 C 102.658 213.216 103.196 212.678 103.86 212.678 C 104.524 212.678 105.062 213.216 105.062 213.88" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 101.32 213.64 C 101.32 214.092 100.953 214.46 100.5 214.46 C 100.047 214.46 99.68 214.092 99.68 213.64 C 99.68 213.187 100.047 212.82 100.5 212.82 C 100.953 212.82 101.32 213.187 101.32 213.64" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 100.011 214.254 L 97.393 212.081 L 92.009 207.812 L 89.363 205.62 L 86.824 203.333 L 84.344 200.86 L 82.45 197.558 L 81.852 193.812 L 82.871 190.134 L 85.025 186.902 L 87.809 184.551 L 91.063 182.763 L 94.457 181.543 L 97.955 180.808 L 101.547 180.479 L 105.109 180.538 L 108.644 180.987 L 112.168 181.834 L 115.552 183.081 L 118.767 184.809 L 121.766 187.122 L 124.208 189.979 L 125.814 193.673 L 126.172 197.66 L 124.959 201.483 L 122.528 204.675 L 119.591 206.826 L 116.602 208.6 L 113.531 210.211 L 110.437 211.747 L 107.381 213.288 L 104.411 214.937 L 103.218 212.85 L 106.171 211.115 L 109.151 209.382 L 112.086 207.636 L 114.918 205.844 L 117.587 203.977 L 119.916 202.113 L 121.607 199.76 L 122.449 197.241 L 122.192 194.595 L 121.059 191.933 L 119.222 189.768 L 116.776 187.817 L 114.067 186.282 L 111.128 185.122 L 107.997 184.288 L 104.833 183.803 L 101.626 183.668 L 98.377 183.884 L 95.244 184.46 L 92.239 185.459 L 89.399 186.932 L 87.09 188.776 L 85.392 191.301 L 84.573 194.029 L 84.817 196.89 L 85.973 199.79 L 87.981 202.176 L 90.395 204.437 L 92.992 206.597 L 95.687 208.708 L 98.403 210.825 L 101.053 212.988" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 103.976 214.24 C 103.976 214.767 103.548 215.196 103.02 215.196 C 102.492 215.196 102.064 214.767 102.064 214.24 C 102.064 213.712 102.492 213.284 103.02 213.284 C 103.548 213.284 103.976 213.712 103.976 214.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 103.976 214.24 C 103.976 214.767 103.547 215.196 103.02 215.196 C 102.493 215.196 102.064 214.767 102.064 214.24 C 102.064 213.713 102.493 213.284 103.02 213.284 C 103.547 213.284 103.976 213.713 103.976 214.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 102.314 214.856 L 101.436 212.014 L 103.835 213.696 L 102.316 214.856 L 101.326 212.099 L 103.833 213.698" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 387.562 81.64 C 387.562 82.58 386.8 83.342 385.86 83.342 C 384.92 83.342 384.158 82.58 384.158 81.64 C 384.158 80.7 384.92 79.938 385.86 79.938 C 386.8 79.938 387.562 80.7 387.562 81.64" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 383.581 81.52 C 383.581 82.117 383.097 82.601 382.5 82.601 C 381.903 82.601 381.419 82.117 381.419 81.52 C 381.419 80.923 381.903 80.439 382.5 80.439 C 383.097 80.439 383.581 80.923 383.581 81.52" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 381.478 81.873 L 380.418 78.648 L 379.343 75.423 L 378.262 72.194 L 377.182 68.964 L 376.112 65.734 L 375.059 62.504 L 373.835 58.663 L 376.57 55.591 L 380.072 58.184 L 381.308 61.655 L 382.364 64.894 L 383.391 68.145 L 384.403 71.4 L 385.413 74.652 L 386.434 77.893 L 387.485 81.12 L 384.252 82.185 L 383.177 78.958 L 382.099 75.724 L 381.019 72.494 L 379.932 69.275 L 378.835 66.07 L 377.723 62.887 L 376.731 59.985 L 376.496 57.675 L 376.323 59.26 L 377.086 61.866 L 378.104 65.085 L 379.165 68.303 L 380.254 71.523 L 381.354 74.744 L 382.451 77.968 L 383.53 81.192" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 117.194 254.14 C 117.194 255.108 116.408 255.894 115.44 255.894 C 114.472 255.894 113.686 255.108 113.686 254.14 C 113.686 253.172 114.472 252.386 115.44 252.386 C 116.408 252.386 117.194 253.172 117.194 254.14" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 117.542 278.2 C 117.542 278.864 117.004 279.402 116.34 279.402 C 115.676 279.402 115.138 278.864 115.138 278.2 C 115.138 277.536 115.676 276.998 116.34 276.998 C 117.004 276.998 117.542 277.536 117.542 278.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 115.673 277.232 L 117.689 275.88 L 119.736 274.564 L 121.728 273.241 L 123.598 271.85 L 125.216 270.302 L 126.496 268.499 L 127.334 266.683 L 127.56 265.121 L 127.181 263.331 L 126.331 261.588 L 125.054 260.196 L 123.348 258.881 L 121.432 257.714 L 119.558 256.807 L 117.423 256.306 L 115.069 255.842 L 115.724 252.396 L 118.141 252.837 L 120.707 253.388 L 123.146 254.438 L 125.448 255.784 L 127.603 257.43 L 129.435 259.469 L 130.772 262.116 L 131.325 265.115 L 130.707 267.926 L 129.058 270.34 L 127.057 272.176 L 125.059 273.701 L 123.052 275.137 L 121.017 276.504 L 119.002 277.843 L 117.03 279.216" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 409.25 101.8 C 409.25 102.788 408.448 103.59 407.46 103.59 C 406.472 103.59 405.67 102.788 405.67 101.8 C 405.67 100.812 406.472 100.01 407.46 100.01 C 408.448 100.01 409.25 100.812 409.25 101.8" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 409.73 102.4 C 409.73 103.388 408.928 104.19 407.94 104.19 C 406.952 104.19 406.15 103.388 406.15 102.4 C 406.15 101.412 406.952 100.61 407.94 100.61 C 408.928 100.61 409.73 101.412 409.73 102.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 406.418 103.4 L 406.213 103.087 L 406.009 102.774 L 409.004 100.813 L 409.208 101.126 L 409.413 101.439" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 394.778 94.6 C 394.778 95.548 394.008 96.318 393.06 96.318 C 392.112 96.318 391.342 95.548 391.342 94.6 C 391.342 93.652 392.112 92.882 393.06 92.882 C 394.008 92.882 394.778 93.652 394.778 94.6" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 399.338 102.58 C 399.338 103.528 398.568 104.298 397.62 104.298 C 396.672 104.298 395.902 103.528 395.902 102.58 C 395.902 101.632 396.672 100.862 397.62 100.862 C 398.568 100.862 399.338 101.632 399.338 102.58" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 396.141 103.468 L 394.996 101.463 L 393.851 99.457 L 391.561 95.447 L 394.545 93.743 L 395.69 95.748 L 396.835 97.754 L 399.125 101.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 407.579 100 C 407.579 100.993 406.773 101.799 405.78 101.799 C 404.787 101.799 403.981 100.993 403.981 100 C 403.981 99.007 404.787 98.201 405.78 98.201 C 406.773 98.201 407.579 99.007 407.579 100" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 412.379 105.52 C 412.379 106.513 411.573 107.319 410.58 107.319 C 409.587 107.319 408.781 106.513 408.781 105.52 C 408.781 104.527 409.587 103.721 410.58 103.721 C 411.573 103.721 412.379 104.527 412.379 105.52" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 409.17 106.686 L 404.45 101.109 L 407.197 98.785 L 411.916 104.363" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 347.974 109.42 C 347.974 110.068 347.448 110.594 346.8 110.594 C 346.152 110.594 345.626 110.068 345.626 109.42 C 345.626 108.772 346.152 108.246 346.8 108.246 C 347.448 108.246 347.974 108.772 347.974 109.42" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 348.814 115.54 C 348.814 116.188 348.288 116.714 347.64 116.714 C 346.992 116.714 346.466 116.188 346.466 115.54 C 346.466 114.892 346.992 114.366 347.64 114.366 C 348.288 114.366 348.814 114.892 348.814 115.54" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 346.497 115.698 L 346.072 112.639 L 345.648 109.58 L 347.974 109.257 L 348.399 112.316 L 348.823 115.375" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 343.345 116.74 C 343.345 117.449 342.769 118.025 342.06 118.025 C 341.351 118.025 340.775 117.449 340.775 116.74 C 340.775 116.031 341.351 115.455 342.06 115.455 C 342.769 115.455 343.345 116.031 343.345 116.74" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 342.265 120.58 C 342.265 121.289 341.689 121.865 340.98 121.865 C 340.271 121.865 339.695 121.289 339.695 120.58 C 339.695 119.871 340.271 119.295 340.98 119.295 C 341.689 119.295 342.265 119.871 342.265 120.58" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 339.718 120.253 L 340.26 118.329 L 340.801 116.406 L 343.275 117.102 L 342.734 119.026 L 342.192 120.949" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 413.572 105.88 C 413.572 106.803 412.823 107.552 411.9 107.552 C 410.977 107.552 410.228 106.803 410.228 105.88 C 410.228 104.957 410.977 104.208 411.9 104.208 C 412.823 104.208 413.572 104.957 413.572 105.88" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 341.733 120.82 C 341.733 121.435 341.235 121.933 340.62 121.933 C 340.005 121.933 339.507 121.435 339.507 120.82 C 339.507 120.205 340.005 119.706 340.62 119.706 C 341.235 119.706 341.733 120.205 341.733 120.82" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 339.517 121.016 L 338.809 117.634 L 338.162 114.147 L 338.16 110.62 L 338.274 107.086 L 338.907 103.353 L 340.732 100.027 L 342.866 97.207 L 344.99 94.483 L 347.276 91.731 L 350.059 89.288 L 353.19 87.465 L 356.292 85.912 L 359.374 84.395 L 362.524 82.889 L 365.893 81.553 L 369.458 80.779 L 372.967 80.404 L 376.396 80.136 L 379.829 79.863 L 383.385 79.669 L 387.081 79.922 L 390.616 80.853 L 393.909 82.001 L 397.163 83.157 L 400.546 84.475 L 403.821 86.53 L 406.324 89.35 L 408.422 92.16 L 410.515 95.154 L 411.875 98.619 L 412.713 102.067 L 413.555 105.393 L 410.327 106.267 L 409.381 102.982 L 408.383 99.839 L 407.131 97.05 L 405.234 94.485 L 403.259 91.801 L 401.305 89.445 L 398.825 87.876 L 395.838 86.7 L 392.65 85.559 L 389.492 84.441 L 386.442 83.557 L 383.333 83.288 L 380.057 83.433 L 376.672 83.694 L 373.283 83.951 L 369.988 84.263 L 366.863 84.859 L 363.866 86.002 L 360.84 87.428 L 357.784 88.927 L 354.766 90.422 L 351.959 91.978 L 349.59 94.002 L 347.499 96.506 L 345.415 99.173 L 343.405 101.792 L 341.868 104.394 L 341.426 107.385 L 341.333 110.686 L 341.253 113.994 L 341.377 117.298 L 341.718 120.674" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 383.663 106.24 C 383.663 107.18 382.9 107.943 381.96 107.943 C 381.02 107.943 380.257 107.18 380.257 106.24 C 380.257 105.3 381.02 104.537 381.96 104.537 C 382.9 104.537 383.663 105.3 383.663 106.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.431 440.5 C 447.431 440.97 447.05 441.351 446.58 441.351 C 446.11 441.351 445.729 440.97 445.729 440.5 C 445.729 440.03 446.11 439.649 446.58 439.649 C 447.05 439.649 447.431 440.03 447.431 440.5" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.779 440.368 L 446.171 437.638 L 446.574 434.908 L 446.984 432.179 L 447.401 429.452 L 447.822 426.725 L 448.245 423.999 L 448.668 421.274 L 449.089 418.549 L 449.507 415.825 L 449.919 413.1 L 450.324 410.376 L 450.72 407.651 L 451.104 404.926 L 451.474 402.2 L 451.83 399.473 L 452.168 396.746 L 452.487 394.017 L 452.785 391.287 L 453.06 388.555 L 453.308 385.822 L 453.529 383.084 L 453.726 380.343 L 453.9 377.6 L 454.052 374.853 L 454.183 372.105 L 454.297 369.355 L 454.394 366.603 L 454.475 363.85 L 454.542 361.097 L 454.597 358.344 L 454.642 355.591 L 454.677 352.838 L 454.705 350.087 L 454.724 347.334 L 454.733 344.581 L 454.732 341.828 L 454.72 339.074 L 454.695 336.321 L 454.658 333.568 L 454.608 330.815 L 454.543 328.063 L 454.463 325.312 L 454.367 322.562 L 454.255 319.813 L 454.125 317.066 L 453.978 314.321 L 453.812 311.578 L 453.629 308.835 L 453.435 306.09 L 453.232 303.346 L 453.017 300.601 L 452.791 297.857 L 452.554 295.114 L 452.306 292.371 L 452.046 289.63 L 451.774 286.89 L 451.489 284.151 L 451.193 281.413 L 450.884 278.678 L 450.562 275.945 L 450.227 273.214 L 449.879 270.485 L 449.517 267.759 L 449.141 265.036 L 448.751 262.316 L 448.341 259.601 L 447.911 256.888 L 447.461 254.176 L 446.991 251.467 L 446.501 248.761 L 445.991 246.059 L 445.462 243.36 L 444.914 240.664 L 444.347 237.974 L 443.761 235.288 L 443.156 232.607 L 442.533 229.932 L 441.892 227.262 L 441.232 224.6 L 440.551 221.944 L 439.846 219.293 L 439.118 216.647 L 438.367 214.006 L 437.595 211.37 L 436.801 208.74 L 435.987 206.115 L 435.153 203.496 L 434.301 200.884 L 433.43 198.278 L 432.542 195.678 L 431.637 193.086 L 430.716 190.5 L 429.781 187.919 L 428.833 185.341 L 427.871 182.767 L 426.895 180.197 L 425.906 177.631 L 424.902 175.071 L 423.883 172.517 L 422.85 169.969 L 421.8 167.428 L 420.735 164.895 L 419.653 162.37 L 418.555 159.854 L 417.439 157.347 L 416.306 154.85 L 415.154 152.362 L 413.986 149.879 L 412.806 147.389 L 411.609 144.907 L 410.387 142.439 L 409.132 139.995 L 407.839 137.584 L 406.498 135.214 L 405.104 132.894 L 403.648 130.632 L 402.124 128.438 L 400.527 126.323 L 398.827 124.297 L 397.02 122.341 L 395.121 120.437 L 393.148 118.574 L 391.118 116.737 L 389.049 114.913 L 386.96 113.087 L 384.868 111.245 L 382.794 109.373 L 380.773 107.471 L 383.109 104.993 L 385.102 106.875 L 387.13 108.719 L 389.194 110.554 L 391.275 112.392 L 393.354 114.249 L 395.415 116.138 L 397.437 118.073 L 399.402 120.069 L 401.291 122.141 L 403.081 124.301 L 404.755 126.543 L 406.336 128.845 L 407.837 131.203 L 409.267 133.608 L 410.634 136.053 L 411.947 138.527 L 413.213 141.023 L 414.44 143.532 L 415.636 146.046 L 416.809 148.555 L 417.968 151.058 L 419.117 153.569 L 420.249 156.092 L 421.363 158.623 L 422.46 161.164 L 423.539 163.712 L 424.601 166.268 L 425.647 168.831 L 426.676 171.401 L 427.689 173.977 L 428.687 176.558 L 429.669 179.144 L 430.636 181.735 L 431.587 184.33 L 432.525 186.928 L 433.447 189.53 L 434.354 192.141 L 435.242 194.76 L 436.112 197.386 L 436.963 200.02 L 437.795 202.66 L 438.607 205.308 L 439.398 207.961 L 440.169 210.621 L 440.917 213.286 L 441.644 215.956 L 442.348 218.632 L 443.028 221.312 L 443.685 223.996 L 444.32 226.683 L 444.937 229.377 L 445.534 232.076 L 446.113 234.78 L 446.672 237.489 L 447.211 240.202 L 447.732 242.92 L 448.233 245.641 L 448.715 248.365 L 449.178 251.092 L 449.622 253.821 L 450.046 256.552 L 450.452 259.285 L 450.838 262.018 L 451.208 264.753 L 451.566 267.489 L 451.911 270.227 L 452.243 272.968 L 452.561 275.711 L 452.868 278.455 L 453.161 281.201 L 453.443 283.949 L 453.713 286.698 L 453.971 289.448 L 454.217 292.199 L 454.453 294.951 L 454.677 297.703 L 454.89 300.455 L 455.093 303.208 L 455.286 305.96 L 455.468 308.712 L 455.64 311.465 L 455.796 314.221 L 455.933 316.979 L 456.052 319.737 L 456.155 322.497 L 456.242 325.258 L 456.314 328.019 L 456.372 330.78 L 456.415 333.542 L 456.446 336.303 L 456.465 339.065 L 456.471 341.826 L 456.467 344.586 L 456.453 347.345 L 456.43 350.103 L 456.397 352.86 L 456.358 355.617 L 456.31 358.376 L 456.251 361.136 L 456.182 363.897 L 456.099 366.659 L 456 369.42 L 455.886 372.181 L 455.753 374.941 L 455.6 377.701 L 455.425 380.458 L 455.227 383.214 L 455.004 385.967 L 454.755 388.717 L 454.478 391.464 L 454.178 394.208 L 453.857 396.949 L 453.517 399.688 L 453.16 402.425 L 452.788 405.159 L 452.403 407.892 L 452.007 410.623 L 451.601 413.353 L 451.189 416.081 L 450.77 418.808 L 450.349 421.534 L 449.926 424.26 L 449.503 426.985 L 449.083 429.71 L 448.667 432.434 L 448.257 435.159 L 447.855 437.883 L 447.463 440.61" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.9 440.56 C 447.9 441.024 447.524 441.4 447.06 441.4 C 446.596 441.4 446.22 441.024 446.22 440.56 C 446.22 440.096 446.596 439.72 447.06 439.72 C 447.524 439.72 447.9 440.096 447.9 440.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.412 440.56 C 447.412 441.019 447.039 441.392 446.58 441.392 C 446.121 441.392 445.748 441.019 445.748 440.56 C 445.748 440.101 446.121 439.728 446.58 439.728 C 447.039 439.728 447.412 440.101 447.412 440.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.594 439.692 L 446.918 439.687 L 447.238 439.731 L 446.95 441.386 L 446.796 441.347 L 446.638 441.355" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 397.492 102.16 C 397.492 103.182 396.662 104.012 395.64 104.012 C 394.618 104.012 393.788 103.182 393.788 102.16 C 393.788 101.138 394.618 100.308 395.64 100.308 C 396.662 100.308 397.492 101.138 397.492 102.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.988 440.5 C 447.988 440.979 447.599 441.368 447.12 441.368 C 446.641 441.368 446.252 440.979 446.252 440.5 C 446.252 440.021 446.641 439.632 447.12 439.632 C 447.599 439.632 447.988 440.021 447.988 440.5" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.538 439.889 L 449.147 437.484 L 451.775 435.092 L 454.417 432.714 L 457.07 430.348 L 459.731 427.989 L 462.395 425.635 L 465.061 423.283 L 467.724 420.931 L 470.381 418.575 L 473.029 416.212 L 475.665 413.84 L 478.285 411.455 L 480.886 409.055 L 483.465 406.637 L 486.019 404.199 L 488.543 401.736 L 491.036 399.246 L 493.493 396.727 L 495.911 394.176 L 498.281 391.59 L 500.591 388.948 L 502.843 386.246 L 505.04 383.489 L 507.184 380.682 L 509.277 377.83 L 511.32 374.938 L 513.316 372.009 L 515.265 369.05 L 517.17 366.064 L 519.033 363.058 L 520.855 360.035 L 522.638 357 L 524.391 353.946 L 526.117 350.862 L 527.808 347.75 L 529.457 344.611 L 531.058 341.446 L 532.605 338.256 L 534.09 335.042 L 535.508 331.805 L 536.85 328.546 L 538.112 325.266 L 539.285 321.968 L 540.366 318.648 L 541.369 315.3 L 542.322 311.915 L 543.221 308.501 L 544.063 305.063 L 544.845 301.603 L 545.564 298.127 L 546.216 294.638 L 546.8 291.142 L 547.311 287.641 L 547.747 284.14 L 548.105 280.643 L 548.382 277.155 L 548.573 273.682 L 548.661 270.234 L 548.579 266.787 L 548.341 263.328 L 547.966 259.857 L 547.474 256.378 L 546.887 252.893 L 546.225 249.406 L 545.508 245.92 L 544.758 242.438 L 543.994 238.962 L 543.234 235.511 L 542.434 232.114 L 541.483 228.767 L 540.392 225.45 L 539.177 222.169 L 537.857 218.93 L 536.445 215.724 L 534.996 212.504 L 533.545 209.264 L 532.086 206.027 L 530.607 202.803 L 529.098 199.6 L 527.547 196.429 L 525.942 193.3 L 524.272 190.223 L 522.528 187.206 L 520.697 184.261 L 518.766 181.39 L 516.739 178.568 L 514.639 175.78 L 512.475 173.027 L 510.254 170.308 L 507.982 167.618 L 505.665 164.956 L 503.309 162.319 L 500.92 159.704 L 498.505 157.109 L 496.07 154.53 L 493.621 151.966 L 491.164 149.413 L 488.708 146.874 L 486.299 144.412 L 483.734 142.216 L 480.95 140.187 L 478.021 138.207 L 475.059 136.181 L 472.158 134.046 L 469.309 131.829 L 466.498 129.571 L 463.707 127.309 L 460.921 125.083 L 458.123 122.929 L 455.299 120.884 L 452.433 118.986 L 449.512 117.27 L 446.518 115.769 L 443.408 114.491 L 440.199 113.351 L 436.924 112.327 L 433.594 111.407 L 430.215 110.577 L 426.794 109.822 L 423.337 109.128 L 419.851 108.479 L 416.343 107.862 L 412.819 107.261 L 409.286 106.661 L 405.75 106.047 L 402.218 105.403 L 398.697 104.715 L 395.212 103.97 L 395.988 100.349 L 399.441 101.09 L 402.907 101.774 L 406.4 102.419 L 409.913 103.039 L 413.44 103.648 L 416.973 104.262 L 420.506 104.896 L 424.033 105.564 L 427.546 106.282 L 431.04 107.065 L 434.507 107.928 L 437.942 108.887 L 441.336 109.958 L 444.689 111.157 L 447.998 112.526 L 451.214 114.142 L 454.318 115.966 L 457.326 117.956 L 460.254 120.072 L 463.121 122.275 L 465.945 124.526 L 468.741 126.787 L 471.527 129.021 L 474.318 131.19 L 477.132 133.259 L 480.036 135.245 L 483.01 137.256 L 485.956 139.412 L 488.74 141.809 L 491.263 144.394 L 493.722 146.952 L 496.179 149.52 L 498.632 152.104 L 501.075 154.708 L 503.5 157.334 L 505.903 159.985 L 508.276 162.663 L 510.614 165.371 L 512.91 168.111 L 515.158 170.887 L 517.352 173.7 L 519.486 176.555 L 521.556 179.457 L 523.541 182.428 L 525.423 185.474 L 527.211 188.579 L 528.916 191.733 L 530.549 194.927 L 532.121 198.151 L 533.643 201.395 L 535.127 204.65 L 536.582 207.907 L 538.02 211.155 L 539.457 214.399 L 540.858 217.685 L 542.154 221.048 L 543.329 224.463 L 544.37 227.923 L 545.264 231.416 L 546 234.91 L 546.704 238.388 L 547.423 241.876 L 548.133 245.385 L 548.811 248.912 L 549.437 252.453 L 549.989 256.004 L 550.446 259.564 L 550.786 263.127 L 550.988 266.69 L 551.031 270.249 L 550.904 273.787 L 550.677 277.319 L 550.367 280.858 L 549.975 284.401 L 549.504 287.946 L 548.959 291.488 L 548.342 295.023 L 547.656 298.547 L 546.905 302.056 L 546.091 305.547 L 545.218 309.016 L 544.288 312.457 L 543.306 315.869 L 542.271 319.25 L 541.156 322.611 L 539.947 325.951 L 538.652 329.269 L 537.278 332.561 L 535.83 335.829 L 534.317 339.07 L 532.743 342.284 L 531.117 345.471 L 529.445 348.629 L 527.733 351.756 L 525.987 354.854 L 524.215 357.919 L 522.413 360.965 L 520.572 364.001 L 518.689 367.022 L 516.764 370.024 L 514.793 373.001 L 512.776 375.949 L 510.709 378.863 L 508.592 381.738 L 506.422 384.569 L 504.197 387.352 L 501.916 390.081 L 499.577 392.751 L 497.181 395.36 L 494.743 397.93 L 492.268 400.465 L 489.76 402.969 L 487.221 405.444 L 484.655 407.895 L 482.065 410.323 L 479.454 412.731 L 476.827 415.123 L 474.185 417.501 L 471.532 419.868 L 468.872 422.228 L 466.208 424.582 L 463.543 426.934 L 460.88 429.287 L 458.223 431.644 L 455.575 434.007 L 452.94 436.379 L 450.32 438.764 L 447.716 441.166" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 366.635 107.02 C 366.635 107.834 365.974 108.495 365.16 108.495 C 364.346 108.495 363.685 107.834 363.685 107.02 C 363.685 106.206 364.346 105.545 365.16 105.545 C 365.974 105.545 366.635 106.206 366.635 107.02" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.93 440.56 C 446.93 441.018 446.558 441.39 446.1 441.39 C 445.642 441.39 445.27 441.018 445.27 440.56 C 445.27 440.102 445.642 439.73 446.1 439.73 C 446.558 439.73 446.93 440.102 446.93 440.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.472 441.136 L 443.506 438.981 L 441.53 436.835 L 439.546 434.695 L 437.554 432.56 L 435.558 430.428 L 433.558 428.298 L 431.556 426.169 L 429.555 424.038 L 427.556 421.905 L 425.562 419.768 L 423.573 417.625 L 421.592 415.475 L 419.62 413.316 L 417.66 411.148 L 415.713 408.968 L 413.782 406.775 L 411.867 404.568 L 409.971 402.344 L 408.096 400.104 L 406.244 397.843 L 404.42 395.557 L 402.627 393.245 L 400.863 390.909 L 399.125 388.552 L 397.413 386.175 L 395.726 383.78 L 394.061 381.369 L 392.417 378.944 L 390.792 376.506 L 389.185 374.059 L 387.595 371.602 L 386.019 369.139 L 384.457 366.671 L 382.906 364.199 L 381.366 361.717 L 379.837 359.226 L 378.321 356.724 L 376.82 354.211 L 375.334 351.688 L 373.866 349.154 L 372.417 346.609 L 370.988 344.053 L 369.58 341.485 L 368.196 338.906 L 366.836 336.314 L 365.503 333.711 L 364.196 331.095 L 362.92 328.468 L 361.663 325.832 L 360.423 323.186 L 359.197 320.531 L 357.988 317.866 L 356.796 315.192 L 355.621 312.509 L 354.465 309.817 L 353.327 307.117 L 352.209 304.409 L 351.112 301.693 L 350.035 298.969 L 348.98 296.239 L 347.947 293.501 L 346.936 290.757 L 345.95 288.006 L 344.986 285.249 L 344.048 282.482 L 343.143 279.699 L 342.27 276.901 L 341.431 274.09 L 340.626 271.266 L 339.855 268.432 L 339.118 265.587 L 338.417 262.734 L 337.752 259.874 L 337.122 257.008 L 336.528 254.137 L 335.972 251.262 L 335.452 248.384 L 334.971 245.5 L 334.533 242.602 L 334.137 239.695 L 333.783 236.78 L 333.47 233.857 L 333.196 230.929 L 332.961 227.997 L 332.764 225.063 L 332.604 222.128 L 332.479 219.194 L 332.39 216.262 L 332.336 213.334 L 332.313 210.411 L 332.317 207.485 L 332.347 204.555 L 332.402 201.623 L 332.485 198.689 L 332.595 195.754 L 332.733 192.819 L 332.9 189.885 L 333.096 186.953 L 333.322 184.025 L 333.579 181.101 L 333.868 178.182 L 334.189 175.269 L 334.542 172.363 L 334.931 169.458 L 335.379 166.55 L 335.887 163.646 L 336.453 160.748 L 337.073 157.86 L 337.746 154.982 L 338.467 152.119 L 339.235 149.272 L 340.046 146.444 L 340.898 143.637 L 341.802 140.831 L 342.874 138.035 L 344.211 135.324 L 345.715 132.722 L 347.301 130.201 L 348.898 127.731 L 350.499 125.276 L 352.138 122.84 L 353.805 120.425 L 355.491 118.027 L 357.191 115.643 L 358.896 113.268 L 360.601 110.898 L 362.298 108.529 L 363.986 106.153 L 366.388 107.864 L 364.688 110.243 L 362.965 112.611 L 361.234 114.967 L 359.505 117.319 L 357.786 119.672 L 356.087 122.032 L 354.416 124.405 L 352.783 126.797 L 351.192 129.219 L 349.626 131.667 L 348.121 134.143 L 346.749 136.646 L 345.565 139.181 L 344.609 141.803 L 343.748 144.525 L 342.905 147.291 L 342.098 150.074 L 341.33 152.873 L 340.604 155.686 L 339.925 158.509 L 339.295 161.342 L 338.719 164.181 L 338.199 167.025 L 337.74 169.872 L 337.339 172.728 L 336.976 175.598 L 336.646 178.478 L 336.348 181.366 L 336.081 184.259 L 335.843 187.158 L 335.636 190.061 L 335.457 192.967 L 335.306 195.875 L 335.182 198.784 L 335.084 201.694 L 335.013 204.602 L 334.966 207.508 L 334.943 210.412 L 334.945 213.31 L 334.975 216.21 L 335.036 219.113 L 335.131 222.018 L 335.259 224.924 L 335.423 227.829 L 335.624 230.732 L 335.863 233.63 L 336.14 236.524 L 336.457 239.41 L 336.816 242.288 L 337.217 245.155 L 337.662 248.012 L 338.148 250.867 L 338.67 253.72 L 339.229 256.57 L 339.823 259.417 L 340.453 262.259 L 341.118 265.094 L 341.819 267.921 L 342.555 270.739 L 343.326 273.547 L 344.132 276.342 L 344.972 279.125 L 345.847 281.893 L 346.756 284.647 L 347.696 287.394 L 348.662 290.135 L 349.653 292.87 L 350.667 295.599 L 351.704 298.321 L 352.764 301.037 L 353.845 303.745 L 354.947 306.445 L 356.069 309.138 L 357.211 311.823 L 358.371 314.499 L 359.55 317.166 L 360.746 319.824 L 361.959 322.474 L 363.188 325.113 L 364.433 327.742 L 365.696 330.359 L 366.987 332.962 L 368.307 335.554 L 369.654 338.134 L 371.027 340.702 L 372.423 343.26 L 373.842 345.806 L 375.282 348.342 L 376.742 350.867 L 378.22 353.381 L 379.714 355.886 L 381.224 358.38 L 382.747 360.865 L 384.283 363.34 L 385.83 365.807 L 387.388 368.268 L 388.96 370.723 L 390.546 373.17 L 392.149 375.608 L 393.77 378.033 L 395.409 380.445 L 397.069 382.842 L 398.75 385.221 L 400.455 387.582 L 402.184 389.922 L 403.939 392.239 L 405.721 394.533 L 407.533 396.8 L 409.374 399.045 L 411.239 401.273 L 413.126 403.484 L 415.032 405.681 L 416.956 407.865 L 418.896 410.037 L 420.85 412.198 L 422.817 414.351 L 424.793 416.496 L 426.778 418.635 L 428.77 420.77 L 430.767 422.902 L 432.767 425.032 L 434.768 427.161 L 436.769 429.293 L 438.767 431.426 L 440.761 433.564 L 442.749 435.708 L 444.729 437.859 L 446.698 440.017" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.411 440.56 C 447.411 441.019 447.039 441.391 446.58 441.391 C 446.121 441.391 445.749 441.019 445.749 440.56 C 445.749 440.101 446.121 439.729 446.58 439.729 C 447.039 439.729 447.411 440.101 447.411 440.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.922 440.62 C 446.922 441.074 446.554 441.442 446.1 441.442 C 445.646 441.442 445.278 441.074 445.278 440.62 C 445.278 440.166 445.646 439.798 446.1 439.798 C 446.554 439.798 446.922 440.166 446.922 440.62" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.91 439.807 L 446.23 439.727 L 446.558 439.694 L 446.674 441.353 L 446.489 441.357 L 446.31 441.402" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.901 440.56 C 447.901 441.024 447.524 441.401 447.06 441.401 C 446.596 441.401 446.219 441.024 446.219 440.56 C 446.219 440.096 446.596 439.719 447.06 439.719 C 447.524 439.719 447.901 440.096 447.901 440.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.267 440.68 C 448.267 441.147 447.887 441.526 447.42 441.526 C 446.953 441.526 446.574 441.147 446.574 440.68 C 446.574 440.213 446.953 439.834 447.42 439.834 C 447.887 439.834 448.267 440.213 448.267 440.68" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.944 441.402 L 446.935 441.359 L 446.897 441.376 L 447.291 439.741 L 447.601 439.841 L 447.887 439.996" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 456.043 119.44 C 456.043 120.457 455.217 121.283 454.2 121.283 C 453.183 121.283 452.357 120.457 452.357 119.44 C 452.357 118.423 453.183 117.597 454.2 117.597 C 455.217 117.597 456.043 118.423 456.043 119.44" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.357 440.68 C 448.357 441.164 447.964 441.557 447.48 441.557 C 446.996 441.557 446.603 441.164 446.603 440.68 C 446.603 440.196 446.996 439.803 447.48 439.803 C 447.964 439.803 448.357 440.196 448.357 440.68" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.119 439.872 L 450.723 438.342 L 454.341 436.831 L 457.967 435.337 L 461.599 433.857 L 465.237 432.388 L 468.878 430.926 L 476.163 428.012 L 479.803 426.553 L 483.439 425.089 L 487.07 423.616 L 490.693 422.131 L 494.306 420.632 L 497.909 419.114 L 501.499 417.574 L 505.073 416.01 L 508.632 414.417 L 512.172 412.794 L 515.692 411.137 L 519.191 409.441 L 522.665 407.705 L 526.108 405.926 L 529.508 404.069 L 532.868 402.123 L 536.191 400.094 L 539.474 397.988 L 542.717 395.808 L 545.919 393.562 L 549.078 391.255 L 552.195 388.892 L 555.267 386.479 L 558.293 384.021 L 561.274 381.524 L 564.203 378.998 L 567.052 376.399 L 569.815 373.7 L 572.505 370.912 L 575.135 368.047 L 577.716 365.121 L 580.26 362.148 L 582.777 359.142 L 585.28 356.117 L 587.78 353.088 L 590.287 350.068 L 592.804 347.065 L 595.344 344.072 L 597.817 341.055 L 600.108 337.973 L 602.116 334.775 L 603.827 331.375 L 605.497 327.874 L 607.138 324.336 L 608.741 320.769 L 610.305 317.179 L 611.824 313.567 L 613.297 309.938 L 614.717 306.293 L 616.084 302.637 L 617.392 298.973 L 618.638 295.304 L 619.803 291.668 L 620.663 288.114 L 620.774 284.434 L 620.469 280.566 L 620.107 276.638 L 619.886 272.681 L 619.751 268.701 L 619.648 264.718 L 619.526 260.754 L 619.333 256.829 L 619.019 252.965 L 618.535 249.184 L 617.832 245.507 L 616.863 241.95 L 615.588 238.494 L 614.088 235.061 L 612.4 231.66 L 610.542 228.301 L 608.534 224.99 L 606.392 221.731 L 604.135 218.531 L 601.78 215.395 L 599.346 212.328 L 596.852 209.336 L 594.315 206.424 L 591.737 203.584 L 589.086 200.802 L 586.368 198.072 L 583.588 195.388 L 580.753 192.745 L 577.871 190.137 L 574.947 187.56 L 571.99 185.006 L 569.006 182.472 L 566.003 179.95 L 562.986 177.437 L 559.963 174.926 L 556.942 172.412 L 553.929 169.889 L 550.933 167.354 L 547.986 164.839 L 544.978 162.474 L 541.853 160.272 L 538.597 158.22 L 535.259 156.201 L 531.911 154.145 L 528.571 152.075 L 525.235 150.002 L 521.898 147.934 L 518.558 145.884 L 515.211 143.86 L 511.852 141.873 L 508.478 139.934 L 505.086 138.051 L 501.671 136.236 L 498.231 134.499 L 494.762 132.849 L 491.272 131.306 L 487.731 129.934 L 484.116 128.721 L 480.432 127.636 L 476.691 126.651 L 472.905 125.737 L 469.086 124.866 L 465.246 124.008 L 461.397 123.133 L 457.552 122.212 L 453.746 121.22 L 454.678 117.655 L 458.448 118.642 L 462.237 119.56 L 466.056 120.442 L 469.895 121.316 L 473.741 122.21 L 477.581 123.155 L 481.403 124.179 L 485.196 125.312 L 488.946 126.585 L 492.635 128.024 L 496.243 129.623 L 499.793 131.313 L 503.304 133.085 L 506.78 134.929 L 510.225 136.836 L 513.644 138.796 L 517.039 140.797 L 520.415 142.83 L 523.775 144.885 L 527.124 146.952 L 530.464 149.02 L 533.799 151.079 L 537.134 153.121 L 540.492 155.147 L 543.857 157.259 L 547.143 159.557 L 550.292 162.024 L 553.288 164.588 L 556.265 167.119 L 559.262 169.638 L 562.273 172.154 L 565.291 174.673 L 568.309 177.2 L 571.319 179.741 L 574.314 182.301 L 577.288 184.886 L 580.233 187.502 L 583.142 190.154 L 586.008 192.848 L 588.823 195.59 L 591.581 198.385 L 594.273 201.238 L 596.888 204.151 L 599.451 207.14 L 601.968 210.217 L 604.423 213.378 L 606.798 216.616 L 609.075 219.926 L 611.238 223.304 L 613.269 226.742 L 615.15 230.237 L 616.863 233.784 L 618.392 237.38 L 619.708 241.052 L 620.714 244.85 L 621.432 248.73 L 621.917 252.669 L 622.223 256.646 L 622.405 260.644 L 622.514 264.642 L 622.604 268.62 L 622.723 272.559 L 622.924 276.438 L 623.253 280.344 L 623.512 284.389 L 623.314 288.485 L 622.348 292.389 L 621.127 296.131 L 619.859 299.836 L 618.53 303.534 L 617.143 307.222 L 615.703 310.897 L 614.211 314.556 L 612.671 318.195 L 611.087 321.811 L 609.461 325.4 L 607.796 328.96 L 606.091 332.494 L 604.281 336.012 L 602.105 339.365 L 599.654 342.522 L 597.062 345.538 L 594.451 348.48 L 591.9 351.43 L 589.377 354.42 L 586.859 357.431 L 584.335 360.446 L 581.791 363.451 L 579.216 366.431 L 576.598 369.37 L 573.925 372.254 L 571.186 375.069 L 568.367 377.798 L 565.463 380.424 L 562.494 382.965 L 559.483 385.469 L 556.424 387.934 L 553.32 390.355 L 550.17 392.726 L 546.975 395.043 L 543.738 397.299 L 540.458 399.49 L 537.136 401.608 L 533.774 403.65 L 530.372 405.609 L 526.933 407.48 L 523.459 409.269 L 519.963 411.012 L 516.446 412.714 L 512.908 414.378 L 509.352 416.007 L 505.779 417.605 L 502.192 419.174 L 498.591 420.718 L 494.979 422.24 L 491.358 423.744 L 487.729 425.232 L 484.094 426.707 L 480.454 428.174 L 476.813 429.634 L 469.53 432.55 L 465.891 434.011 L 462.258 435.48 L 458.631 436.958 L 455.012 438.45 L 451.404 439.958 L 447.804 441.487" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 353.822 112.18 C 353.822 113.075 353.095 113.802 352.2 113.802 C 351.305 113.802 350.578 113.075 350.578 112.18 C 350.578 111.285 351.305 110.558 352.2 110.558 C 353.095 110.558 353.822 111.285 353.822 112.18" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.49 440.74 C 446.49 441.187 446.127 441.55 445.68 441.55 C 445.233 441.55 444.87 441.187 444.87 440.74 C 444.87 440.293 445.233 439.93 445.68 439.93 C 446.127 439.93 446.49 440.293 446.49 440.74" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.396 441.526 L 441.985 440.311 L 438.567 439.114 L 435.141 437.932 L 431.71 436.762 L 428.273 435.6 L 424.832 434.445 L 417.947 432.139 L 414.504 430.984 L 411.063 429.822 L 407.626 428.652 L 404.193 427.47 L 400.767 426.273 L 397.347 425.058 L 393.937 423.823 L 390.537 422.564 L 387.148 421.278 L 383.773 419.963 L 380.411 418.615 L 377.066 417.232 L 373.736 415.81 L 370.428 414.336 L 367.146 412.787 L 363.893 411.168 L 360.667 409.483 L 357.471 407.736 L 354.303 405.934 L 351.163 404.08 L 348.052 402.18 L 344.969 400.238 L 341.915 398.258 L 338.889 396.247 L 335.891 394.207 L 332.92 392.145 L 329.967 390.051 L 327.026 387.918 L 324.103 385.743 L 321.206 383.524 L 318.341 381.258 L 315.515 378.944 L 312.734 376.578 L 310.005 374.16 L 307.336 371.687 L 304.732 369.157 L 302.2 366.567 L 299.746 363.914 L 297.365 361.189 L 295.05 358.396 L 292.798 355.542 L 290.603 352.635 L 288.462 349.682 L 286.368 346.69 L 284.319 343.668 L 282.308 340.621 L 280.333 337.558 L 278.387 334.486 L 276.467 331.412 L 274.552 328.326 L 272.791 325.121 L 271.308 321.752 L 270.029 318.304 L 268.866 314.834 L 267.736 311.397 L 266.554 307.98 L 265.321 304.555 L 264.069 301.117 L 262.829 297.665 L 261.635 294.197 L 260.517 290.709 L 259.509 287.2 L 258.642 283.666 L 257.951 280.105 L 257.469 276.519 L 257.197 272.907 L 257.106 269.273 L 257.172 265.624 L 257.371 261.966 L 257.676 258.305 L 258.065 254.648 L 258.513 251.003 L 258.995 247.376 L 259.487 243.773 L 259.97 240.156 L 260.708 236.538 L 261.766 232.992 L 262.962 229.527 L 264.135 226.108 L 265.225 222.675 L 266.28 219.212 L 267.311 215.731 L 268.332 212.238 L 269.356 208.74 L 270.398 205.244 L 271.47 201.757 L 272.588 198.286 L 273.765 194.836 L 275.015 191.416 L 276.352 188.031 L 277.79 184.69 L 279.342 181.4 L 281.013 178.16 L 282.793 174.968 L 284.668 171.822 L 286.626 168.72 L 288.654 165.66 L 290.739 162.641 L 292.867 159.66 L 295.027 156.715 L 297.206 153.805 L 299.406 150.898 L 301.821 148.02 L 304.804 145.637 L 307.879 143.594 L 310.765 141.48 L 313.637 139.296 L 316.523 137.103 L 322.295 132.721 L 330.958 126.152 L 342.513 117.402 L 348.292 113.029 L 351.182 110.844 L 353.137 113.433 L 350.244 115.615 L 341.558 122.153 L 324.181 135.217 L 321.286 137.395 L 318.392 139.574 L 312.593 143.945 L 309.605 146.097 L 306.539 148.067 L 303.835 150.119 L 301.643 152.695 L 299.47 155.52 L 297.291 158.401 L 295.136 161.31 L 293.017 164.248 L 290.945 167.218 L 288.935 170.221 L 286.997 173.258 L 285.145 176.332 L 283.39 179.443 L 281.745 182.593 L 280.217 185.791 L 278.798 189.047 L 277.474 192.357 L 276.23 195.713 L 275.053 199.109 L 273.931 202.538 L 272.85 205.993 L 271.797 209.468 L 270.759 212.954 L 269.721 216.446 L 268.671 219.936 L 267.594 223.417 L 266.476 226.888 L 265.27 230.331 L 264.061 233.74 L 263.018 237.129 L 262.284 240.558 L 261.778 244.093 L 261.256 247.691 L 260.743 251.299 L 260.263 254.912 L 259.841 258.522 L 259.501 262.124 L 259.268 265.711 L 259.167 269.277 L 259.222 272.815 L 259.457 276.318 L 259.9 279.791 L 260.553 283.252 L 261.384 286.704 L 262.362 290.152 L 263.455 293.594 L 264.63 297.034 L 265.856 300.473 L 267.101 303.913 L 268.33 307.356 L 269.51 310.803 L 270.625 314.257 L 271.747 317.707 L 272.964 321.091 L 274.361 324.356 L 276.034 327.468 L 277.904 330.522 L 279.809 333.595 L 281.737 336.664 L 283.693 339.721 L 285.683 342.759 L 287.709 345.77 L 289.778 348.747 L 291.894 351.683 L 294.06 354.571 L 296.282 357.402 L 298.565 360.171 L 300.912 362.869 L 303.331 365.493 L 305.83 368.057 L 308.403 370.563 L 311.045 373.014 L 313.747 375.412 L 316.504 377.758 L 319.309 380.055 L 322.155 382.305 L 325.034 384.51 L 327.942 386.671 L 330.869 388.792 L 333.811 390.874 L 336.77 392.926 L 339.757 394.954 L 342.771 396.952 L 345.812 398.916 L 348.881 400.842 L 351.976 402.725 L 355.097 404.561 L 358.246 406.344 L 361.42 408.071 L 364.621 409.736 L 367.848 411.337 L 371.101 412.867 L 374.384 414.325 L 377.694 415.737 L 381.023 417.112 L 384.369 418.453 L 387.731 419.762 L 391.107 421.042 L 394.496 422.296 L 397.896 423.528 L 401.307 424.74 L 404.726 425.934 L 408.152 427.114 L 411.585 428.284 L 415.022 429.444 L 418.463 430.6 L 425.349 432.906 L 428.791 434.063 L 432.231 435.226 L 435.668 436.398 L 439.099 437.583 L 442.525 438.783 L 445.94 439.999" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.923 440.62 C 446.923 441.074 446.554 441.443 446.1 441.443 C 445.646 441.443 445.277 441.074 445.277 440.62 C 445.277 440.166 445.646 439.797 446.1 439.797 C 446.554 439.797 446.923 440.166 446.923 440.62" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.555 440.8 C 446.555 441.25 446.19 441.615 445.74 441.615 C 445.29 441.615 444.925 441.25 444.925 440.8 C 444.925 440.35 445.29 439.985 445.74 439.985 C 446.19 439.985 446.555 440.35 446.555 440.8" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.298 440.076 L 445.574 439.921 L 445.872 439.817 L 446.348 441.392 L 446.227 441.414 L 446.126 441.481" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.268 440.68 C 448.268 441.148 447.888 441.528 447.42 441.528 C 446.952 441.528 446.572 441.148 446.572 440.68 C 446.572 440.212 446.952 439.832 447.42 439.832 C 447.888 439.832 448.268 440.212 448.268 440.68" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.389 440.92 C 448.389 441.389 448.009 441.769 447.54 441.769 C 447.071 441.769 446.691 441.389 446.691 440.92 C 446.691 440.451 447.071 440.071 447.54 440.071 C 448.009 440.071 448.389 440.451 448.389 440.92" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.648 440.849 L 446.781 441.057 L 446.816 441.3 L 448.015 440.099 L 448.226 440.516 L 448.342 440.968" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 620.17 246.16 C 620.17 247.159 619.359 247.97 618.36 247.97 C 617.361 247.97 616.55 247.159 616.55 246.16 C 616.55 245.161 617.361 244.35 618.36 244.35 C 619.359 244.35 620.17 245.161 620.17 246.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.415 440.92 C 448.415 441.403 448.023 441.795 447.54 441.795 C 447.057 441.795 446.665 441.403 446.665 440.92 C 446.665 440.437 447.057 440.045 447.54 440.045 C 448.023 440.045 448.415 440.437 448.415 440.92" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.379 440.04 L 449.972 439.593 L 452.569 439.157 L 455.169 438.731 L 457.771 438.313 L 460.374 437.903 L 462.979 437.499 L 465.585 437.101 L 468.192 436.706 L 473.408 435.925 L 478.622 435.147 L 481.228 434.756 L 483.833 434.363 L 486.436 433.965 L 489.038 433.563 L 491.637 433.154 L 494.234 432.739 L 496.828 432.315 L 499.419 431.881 L 502.006 431.437 L 504.59 430.981 L 507.169 430.512 L 509.744 430.03 L 512.314 429.532 L 514.879 429.018 L 517.439 428.486 L 519.992 427.936 L 522.54 427.367 L 525.081 426.776 L 527.614 426.164 L 530.132 425.528 L 532.621 424.829 L 535.086 424.053 L 537.534 423.206 L 539.967 422.297 L 542.386 421.332 L 544.794 420.319 L 547.192 419.266 L 549.583 418.18 L 551.969 417.068 L 554.352 415.939 L 556.734 414.799 L 559.116 413.655 L 561.502 412.517 L 563.893 411.391 L 566.292 410.284 L 568.698 409.202 L 571.114 408.145 L 573.532 407.097 L 575.935 406.036 L 578.306 404.94 L 580.632 403.788 L 582.897 402.558 L 585.094 401.227 L 587.251 399.794 L 589.407 398.326 L 591.551 396.832 L 593.683 395.316 L 595.804 393.779 L 597.914 392.224 L 600.016 390.652 L 602.108 389.065 L 604.193 387.466 L 606.271 385.856 L 608.343 384.236 L 610.41 382.61 L 612.473 380.979 L 614.533 379.344 L 616.589 377.707 L 618.648 376.069 L 620.729 374.438 L 622.778 372.793 L 624.729 371.097 L 626.52 369.316 L 628.106 367.406 L 629.526 365.309 L 630.952 363.134 L 632.366 360.932 L 633.764 358.708 L 635.142 356.465 L 636.499 354.203 L 637.833 351.925 L 639.14 349.633 L 640.419 347.328 L 641.667 345.011 L 642.882 342.686 L 644.062 340.352 L 645.203 338.013 L 646.305 335.67 L 647.364 333.325 L 648.332 331.083 L 648.795 328.878 L 648.705 326.476 L 648.345 323.86 L 648.012 321.17 L 647.849 318.488 L 647.755 315.809 L 647.705 313.123 L 647.678 310.438 L 647.651 307.761 L 647.603 305.101 L 647.514 302.466 L 647.362 299.865 L 647.127 297.306 L 646.789 294.797 L 646.328 292.348 L 645.726 289.965 L 644.961 287.646 L 644.036 285.359 L 642.997 283.089 L 641.856 280.846 L 640.625 278.626 L 639.312 276.428 L 637.928 274.247 L 636.481 272.081 L 634.983 269.929 L 633.444 267.786 L 631.872 265.65 L 630.279 263.518 L 628.674 261.387 L 627.069 259.254 L 625.472 257.115 L 623.894 254.968 L 622.347 252.827 L 620.896 250.845 L 619.123 249.188 L 617.166 247.481 L 619.563 244.767 L 621.564 246.556 L 623.548 248.56 L 625.144 250.83 L 626.651 252.983 L 628.192 255.119 L 629.758 257.258 L 631.339 259.402 L 632.925 261.556 L 634.506 263.72 L 636.071 265.898 L 637.611 268.093 L 639.114 270.308 L 640.572 272.546 L 641.973 274.809 L 643.308 277.101 L 644.565 279.425 L 645.734 281.784 L 646.804 284.182 L 647.768 286.632 L 648.573 289.151 L 649.201 291.728 L 649.671 294.344 L 650.009 296.99 L 650.237 299.658 L 650.377 302.343 L 650.453 305.036 L 650.487 307.73 L 650.499 310.417 L 650.511 313.091 L 650.545 315.743 L 650.621 318.365 L 650.758 320.931 L 651.043 323.535 L 651.35 326.286 L 651.357 329.13 L 650.731 331.858 L 649.646 334.339 L 648.558 336.715 L 647.43 339.086 L 646.262 341.451 L 645.057 343.809 L 643.818 346.158 L 642.547 348.497 L 641.245 350.822 L 639.915 353.134 L 638.56 355.43 L 637.182 357.708 L 635.782 359.967 L 634.364 362.206 L 632.929 364.422 L 631.478 366.617 L 629.966 368.814 L 628.218 370.883 L 626.273 372.775 L 624.213 374.528 L 622.102 376.187 L 620.001 377.798 L 617.94 379.414 L 613.812 382.673 L 611.742 384.302 L 609.667 385.928 L 607.585 387.547 L 605.496 389.16 L 603.4 390.762 L 601.294 392.353 L 599.178 393.93 L 597.052 395.491 L 594.914 397.034 L 592.762 398.557 L 590.597 400.057 L 588.417 401.534 L 586.207 402.99 L 583.922 404.358 L 581.57 405.612 L 579.176 406.775 L 576.753 407.869 L 574.32 408.919 L 571.889 409.946 L 569.476 410.976 L 567.083 412.033 L 564.696 413.122 L 562.311 414.233 L 559.926 415.358 L 557.539 416.489 L 555.148 417.62 L 552.751 418.742 L 550.346 419.849 L 547.932 420.932 L 545.505 421.985 L 543.065 422.999 L 540.608 423.967 L 538.133 424.881 L 535.638 425.734 L 533.121 426.518 L 530.583 427.224 L 528.033 427.863 L 525.483 428.476 L 522.927 429.068 L 520.365 429.639 L 517.798 430.19 L 515.227 430.722 L 512.65 431.238 L 510.069 431.737 L 507.484 432.221 L 504.896 432.691 L 502.304 433.148 L 499.709 433.594 L 497.112 434.028 L 494.512 434.454 L 491.91 434.871 L 489.306 435.281 L 486.701 435.684 L 484.094 436.083 L 481.487 436.477 L 476.273 437.26 L 471.059 438.04 L 468.453 438.432 L 465.848 438.827 L 463.245 439.226 L 460.644 439.63 L 458.045 440.04 L 455.449 440.457 L 452.856 440.883 L 450.265 441.318 L 447.676 441.765" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 286.599 175.48 C 286.599 176.329 285.909 177.019 285.06 177.019 C 284.211 177.019 283.521 176.329 283.521 175.48 C 283.521 174.631 284.211 173.941 285.06 173.941 C 285.909 173.941 286.599 174.631 286.599 175.48" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.298 440.98 C 446.298 441.42 445.94 441.778 445.5 441.778 C 445.06 441.778 444.702 441.42 444.702 440.98 C 444.702 440.54 445.06 440.182 445.5 440.182 C 445.94 440.182 446.298 440.54 446.298 440.98" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.426 441.792 L 441.964 441.541 L 438.499 441.306 L 435.032 441.085 L 431.562 440.877 L 428.09 440.678 L 424.617 440.486 L 421.141 440.299 L 410.711 439.746 L 407.234 439.556 L 403.758 439.361 L 400.283 439.156 L 396.809 438.94 L 393.337 438.712 L 389.867 438.467 L 386.399 438.205 L 382.935 437.923 L 379.474 437.618 L 376.017 437.288 L 372.563 436.931 L 369.115 436.546 L 365.671 436.128 L 362.232 435.676 L 358.795 435.183 L 355.367 434.599 L 351.953 433.916 L 348.554 433.147 L 345.17 432.301 L 341.8 431.389 L 338.443 430.42 L 335.099 429.405 L 331.766 428.354 L 328.445 427.278 L 325.133 426.185 L 318.537 423.992 L 315.224 422.895 L 311.977 421.549 L 308.838 419.959 L 305.774 418.274 L 302.726 416.63 L 299.637 415.079 L 296.504 413.571 L 293.343 412.094 L 286.982 409.164 L 283.807 407.68 L 280.652 406.161 L 277.528 404.592 L 274.449 402.956 L 271.427 401.238 L 268.473 399.419 L 265.6 397.484 L 262.822 395.419 L 260.14 393.226 L 257.543 390.921 L 255.022 388.52 L 252.564 386.04 L 250.161 383.496 L 247.799 380.903 L 245.47 378.279 L 243.163 375.639 L 240.866 372.998 L 238.57 370.373 L 236.263 367.78 L 233.923 365.222 L 231.551 362.603 L 229.31 359.823 L 227.409 356.819 L 225.955 353.639 L 224.553 350.448 L 223.156 347.216 L 221.795 343.944 L 220.505 340.635 L 219.318 337.293 L 218.27 333.923 L 217.394 330.529 L 216.727 327.114 L 216.304 323.686 L 216.135 320.24 L 216.181 316.776 L 216.413 313.3 L 216.799 309.816 L 217.308 306.33 L 217.909 302.847 L 218.572 299.372 L 219.266 295.91 L 219.963 292.468 L 220.628 289.048 L 221.246 285.608 L 222.08 282.161 L 223.176 278.781 L 224.413 275.491 L 225.679 272.256 L 226.922 269.017 L 228.151 265.766 L 229.373 262.505 L 230.593 259.24 L 231.821 255.974 L 233.061 252.71 L 234.321 249.453 L 235.608 246.207 L 236.928 242.975 L 238.289 239.761 L 239.697 236.57 L 241.16 233.405 L 242.683 230.271 L 244.275 227.171 L 245.939 224.111 L 247.669 221.086 L 249.46 218.092 L 251.306 215.129 L 253.203 212.193 L 255.144 209.284 L 257.123 206.399 L 259.137 203.536 L 261.178 200.695 L 263.242 197.872 L 265.322 195.065 L 267.415 192.275 L 269.513 189.497 L 271.612 186.731 L 273.726 183.937 L 276.04 181.204 L 278.695 178.768 L 281.423 176.541 L 284.076 174.306 L 286.051 176.666 L 283.362 178.903 L 280.642 181.057 L 278.142 183.259 L 275.971 185.754 L 273.885 188.464 L 271.777 191.218 L 269.673 193.981 L 267.578 196.754 L 265.497 199.538 L 263.435 202.337 L 261.398 205.15 L 259.391 207.981 L 257.42 210.831 L 255.49 213.701 L 253.606 216.594 L 251.774 219.511 L 249.998 222.454 L 248.285 225.425 L 246.64 228.426 L 245.065 231.467 L 243.555 234.546 L 242.102 237.661 L 240.7 240.809 L 239.343 243.984 L 238.023 247.183 L 236.734 250.403 L 235.47 253.638 L 234.224 256.886 L 232.988 260.142 L 231.757 263.402 L 230.524 266.663 L 229.281 269.92 L 228.022 273.169 L 226.745 276.394 L 225.508 279.609 L 224.424 282.838 L 223.588 286.117 L 222.936 289.494 L 222.23 292.93 L 221.496 296.372 L 220.764 299.815 L 220.064 303.253 L 219.426 306.682 L 218.883 310.097 L 218.463 313.495 L 218.196 316.869 L 218.114 320.215 L 218.245 323.528 L 218.625 326.82 L 219.246 330.116 L 220.077 333.414 L 221.086 336.708 L 222.239 339.992 L 223.503 343.259 L 224.842 346.504 L 226.224 349.722 L 227.612 352.901 L 228.991 355.968 L 230.761 358.788 L 232.899 361.455 L 235.225 364.043 L 237.557 366.617 L 239.866 369.234 L 242.159 371.875 L 244.446 374.525 L 246.737 377.169 L 249.043 379.791 L 251.375 382.374 L 253.744 384.904 L 256.16 387.364 L 258.635 389.738 L 261.178 392.011 L 263.8 394.168 L 266.514 396.194 L 269.327 398.094 L 272.229 399.882 L 275.208 401.575 L 278.252 403.19 L 281.349 404.742 L 284.486 406.247 L 287.651 407.721 L 294.015 410.643 L 297.19 412.124 L 300.344 413.64 L 303.467 415.208 L 306.54 416.873 L 309.58 418.566 L 312.63 420.139 L 315.763 421.456 L 319.019 422.54 L 325.615 424.728 L 328.922 425.815 L 332.235 426.884 L 335.555 427.924 L 338.883 428.927 L 342.219 429.883 L 345.564 430.781 L 348.918 431.613 L 352.281 432.368 L 355.655 433.036 L 359.042 433.609 L 362.449 434.095 L 365.871 434.543 L 369.3 434.958 L 372.734 435.342 L 376.174 435.696 L 379.62 436.024 L 383.07 436.328 L 386.525 436.609 L 389.983 436.871 L 393.446 437.115 L 396.911 437.343 L 400.379 437.559 L 403.85 437.763 L 407.323 437.959 L 410.797 438.149 L 414.273 438.335 L 421.227 438.703 L 424.704 438.891 L 428.18 439.083 L 431.656 439.283 L 435.131 439.492 L 438.604 439.713 L 442.075 439.949 L 445.542 440.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.557 440.8 C 446.557 441.251 446.191 441.617 445.74 441.617 C 445.289 441.617 444.923 441.251 444.923 440.8 C 444.923 440.349 445.289 439.983 445.74 439.983 C 446.191 439.983 446.557 440.349 446.557 440.8" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.313 440.98 C 446.313 441.429 445.949 441.793 445.5 441.793 C 445.051 441.793 444.687 441.429 444.687 440.98 C 444.687 440.531 445.051 440.167 445.5 440.167 C 445.949 440.167 446.313 440.531 446.313 440.98" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 444.79 440.66 L 444.982 440.364 L 445.236 440.115 L 446.188 441.442 L 446.198 441.368 L 446.267 441.339" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.391 440.92 C 448.391 441.39 448.01 441.771 447.54 441.771 C 447.07 441.771 446.689 441.39 446.689 440.92 C 446.689 440.45 447.07 440.069 447.54 440.069 C 448.01 440.069 448.391 440.45 448.391 440.92" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.147 441.16 C 448.147 441.628 447.768 442.007 447.3 442.007 C 446.832 442.007 446.453 441.628 446.453 441.16 C 446.453 440.692 446.832 440.313 447.3 440.313 C 447.768 440.313 448.147 440.692 448.147 441.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.818 440.44 L 446.801 440.518 L 446.723 440.55 L 448.267 441.266 L 448.065 441.565 L 447.803 441.818" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.315 440.98 C 446.315 441.43 445.95 441.795 445.5 441.795 C 445.05 441.795 444.685 441.43 444.685 440.98 C 444.685 440.53 445.05 440.165 445.5 440.165 C 445.95 440.165 446.315 440.53 446.315 440.98" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.436 441.22 C 446.436 441.67 446.07 442.036 445.62 442.036 C 445.17 442.036 444.804 441.67 444.804 441.22 C 444.804 440.77 445.17 440.404 445.62 440.404 C 446.07 440.404 446.436 440.77 446.436 441.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.034 441.787 L 444.827 441.384 L 444.716 440.945 L 446.341 441.053 L 446.214 440.858 L 446.183 440.629" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.149 441.16 C 448.149 441.629 447.769 442.009 447.3 442.009 C 446.831 442.009 446.451 441.629 446.451 441.16 C 446.451 440.691 446.831 440.311 447.3 440.311 C 447.769 440.311 448.149 440.691 448.149 441.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.781 441.28 C 447.781 441.744 447.404 442.121 446.94 442.121 C 446.476 442.121 446.099 441.744 446.099 441.28 C 446.099 440.816 446.476 440.439 446.94 440.439 C 447.404 440.439 447.781 440.816 447.781 441.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.67 440.498 L 446.786 440.471 L 446.881 440.397 L 447.74 441.861 L 447.459 442.009 L 447.155 442.108" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.437 441.22 C 446.437 441.671 446.071 442.037 445.62 442.037 C 445.169 442.037 444.803 441.671 444.803 441.22 C 444.803 440.769 445.169 440.403 445.62 440.403 C 446.071 440.403 446.437 440.769 446.437 441.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.743 441.34 C 446.743 441.794 446.374 442.163 445.92 442.163 C 445.466 442.163 445.097 441.794 445.097 441.34 C 445.097 440.886 445.466 440.517 445.92 440.517 C 446.374 440.517 446.743 440.886 446.743 441.34" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.738 442.149 L 445.433 442.046 L 445.154 441.887 L 446.063 440.529 L 446.079 440.567 L 446.122 440.548" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.782 441.28 C 447.782 441.745 447.405 442.122 446.94 442.122 C 446.475 442.122 446.098 441.745 446.098 441.28 C 446.098 440.815 446.475 440.438 446.94 440.438 C 447.405 440.438 447.782 440.815 447.782 441.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.232 441.4 C 447.232 441.859 446.859 442.232 446.4 442.232 C 445.941 442.232 445.568 441.859 445.568 441.4 C 445.568 440.941 445.941 440.568 446.4 440.568 C 446.859 440.568 447.232 440.941 447.232 441.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.35 440.553 L 446.532 440.541 L 446.708 440.486 L 447.117 442.12 L 446.795 442.19 L 446.465 442.214" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.233 441.4 C 447.233 441.86 446.86 442.233 446.4 442.233 C 445.94 442.233 445.568 441.86 445.568 441.4 C 445.568 440.94 445.94 440.567 446.4 440.567 C 446.86 440.567 447.233 440.94 447.233 441.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.744 441.34 C 446.744 441.795 446.375 442.164 445.92 442.164 C 445.465 442.164 445.096 441.795 445.096 441.34 C 445.096 440.885 445.465 440.516 445.92 440.516 C 446.375 440.516 446.744 440.885 446.744 441.34" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.071 440.537 L 446.227 440.566 L 446.385 440.551 L 446.43 442.215 L 446.107 442.213 L 445.789 442.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 626.913 371.2 C 626.913 372.046 626.226 372.733 625.38 372.733 C 624.534 372.733 623.847 372.046 623.847 371.2 C 623.847 370.354 624.534 369.667 625.38 369.667 C 626.226 369.667 626.913 370.354 626.913 371.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 448.163 441.16 C 448.163 441.636 447.776 442.023 447.3 442.023 C 446.824 442.023 446.438 441.636 446.438 441.16 C 446.438 440.684 446.824 440.297 447.3 440.297 C 447.776 440.297 448.163 440.684 448.163 441.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.393 440.27 L 450.691 440.507 L 453.99 440.758 L 457.29 441.019 L 460.589 441.289 L 463.888 441.564 L 473.782 442.403 L 477.079 442.679 L 480.375 442.948 L 483.669 443.208 L 486.962 443.458 L 490.254 443.693 L 493.544 443.913 L 496.832 444.115 L 500.119 444.295 L 503.403 444.452 L 506.685 444.584 L 509.953 444.686 L 513.152 444.675 L 516.296 444.209 L 519.469 443.436 L 522.687 442.565 L 525.93 441.807 L 529.17 441.113 L 532.406 440.43 L 535.643 439.751 L 538.877 439.068 L 542.107 438.378 L 545.332 437.675 L 548.549 436.952 L 551.757 436.204 L 554.954 435.425 L 558.136 434.61 L 561.287 433.746 L 564.392 432.751 L 567.449 431.607 L 570.445 430.317 L 573.373 428.887 L 576.271 427.36 L 579.172 425.799 L 582.062 424.21 L 584.937 422.59 L 587.795 420.94 L 590.632 419.259 L 593.445 417.544 L 596.23 415.797 L 598.984 414.014 L 601.675 412.2 L 604.236 410.229 L 606.579 408.041 L 608.617 405.626 L 610.4 402.968 L 612.18 400.209 L 613.93 397.406 L 615.642 394.569 L 617.309 391.702 L 618.923 388.812 L 620.479 385.904 L 621.968 382.985 L 623.383 380.062 L 624.61 377.326 L 624.728 374.65 L 623.913 371.567 L 626.903 370.885 L 627.602 374.442 L 627.122 377.984 L 625.619 381.129 L 624.151 384.084 L 622.615 387.031 L 621.017 389.966 L 619.363 392.881 L 617.66 395.772 L 615.913 398.631 L 614.129 401.454 L 612.312 404.237 L 610.417 407 L 608.173 409.58 L 605.616 411.883 L 602.891 413.91 L 600.113 415.739 L 597.324 417.523 L 594.509 419.273 L 591.669 420.99 L 588.806 422.675 L 585.924 424.327 L 583.026 425.948 L 580.115 427.539 L 577.194 429.1 L 574.255 430.636 L 571.249 432.084 L 568.159 433.389 L 565.008 434.544 L 561.816 435.545 L 558.608 436.407 L 555.399 437.219 L 552.181 437.994 L 548.956 438.738 L 545.725 439.457 L 542.489 440.155 L 539.251 440.839 L 536.012 441.515 L 532.775 442.188 L 529.54 442.864 L 526.317 443.547 L 523.118 444.285 L 519.904 445.142 L 516.626 445.922 L 513.281 446.4 L 509.929 446.413 L 506.623 446.307 L 503.327 446.174 L 500.03 446.015 L 496.732 445.833 L 493.434 445.631 L 490.135 445.41 L 486.836 445.174 L 483.536 444.924 L 480.237 444.664 L 476.937 444.395 L 473.638 444.119 L 470.339 443.841 L 463.744 443.282 L 460.447 443.007 L 457.151 442.738 L 453.857 442.477 L 450.564 442.227 L 447.27 441.991" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 227.497 351.22 C 227.497 351.87 226.97 352.397 226.32 352.397 C 225.67 352.397 225.143 351.87 225.143 351.22 C 225.143 350.57 225.67 350.043 226.32 350.043 C 226.97 350.043 227.497 350.57 227.497 351.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.356 441.22 C 446.356 441.659 445.999 442.016 445.56 442.016 C 445.121 442.016 444.764 441.659 444.764 441.22 C 444.764 440.781 445.121 440.424 445.56 440.424 C 445.999 440.424 446.356 440.781 446.356 441.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 445.695 442 L 443.551 442.31 L 441.409 442.63 L 439.267 442.957 L 437.125 443.291 L 434.983 443.631 L 432.84 443.977 L 430.697 444.327 L 428.554 444.682 L 426.411 445.039 L 422.124 445.76 L 417.836 446.484 L 413.547 447.204 L 411.402 447.56 L 409.256 447.914 L 407.11 448.263 L 404.964 448.608 L 402.817 448.947 L 400.67 449.279 L 398.522 449.604 L 396.374 449.921 L 394.225 450.229 L 392.076 450.528 L 389.926 450.816 L 387.776 451.093 L 385.625 451.358 L 383.473 451.61 L 381.321 451.848 L 379.168 452.072 L 377.015 452.281 L 374.861 452.473 L 372.706 452.649 L 370.549 452.807 L 368.383 452.94 L 366.21 453.005 L 364.036 453.002 L 361.862 452.938 L 359.69 452.82 L 357.519 452.653 L 355.35 452.446 L 353.182 452.204 L 351.016 451.934 L 348.852 451.644 L 346.69 451.338 L 344.531 451.025 L 342.373 450.71 L 340.218 450.401 L 338.066 450.103 L 335.917 449.824 L 333.771 449.569 L 331.629 449.348 L 329.481 449.176 L 327.316 449.04 L 325.139 448.915 L 322.956 448.774 L 320.771 448.592 L 318.59 448.343 L 316.419 448.001 L 314.272 447.539 L 312.162 446.972 L 310.076 446.368 L 307.999 445.731 L 305.931 445.064 L 303.87 444.373 L 301.815 443.659 L 299.766 442.926 L 297.722 442.179 L 295.682 441.421 L 293.646 440.655 L 291.612 439.885 L 289.579 439.114 L 287.548 438.347 L 285.516 437.586 L 283.484 436.835 L 281.453 436.099 L 279.43 435.399 L 277.36 434.789 L 275.24 434.217 L 273.104 433.62 L 270.989 432.933 L 268.931 432.091 L 266.984 431.031 L 265.189 429.773 L 263.456 428.482 L 261.745 427.157 L 260.053 425.799 L 258.378 424.412 L 256.72 422.999 L 255.077 421.562 L 253.448 420.104 L 251.833 418.629 L 250.231 417.139 L 248.639 415.638 L 247.058 414.127 L 245.487 412.611 L 243.923 411.092 L 242.367 409.573 L 240.817 408.057 L 239.263 406.539 L 237.727 404.962 L 236.263 403.264 L 234.922 401.453 L 233.755 399.531 L 232.82 397.533 L 231.976 395.53 L 231.139 393.525 L 230.309 391.503 L 229.49 389.467 L 228.689 387.417 L 227.912 385.355 L 227.165 383.282 L 226.453 381.199 L 225.783 379.107 L 225.159 377.008 L 224.589 374.902 L 224.078 372.79 L 223.631 370.672 L 223.252 368.522 L 223.072 366.32 L 223.117 364.1 L 223.335 361.885 L 223.669 359.681 L 224.068 357.494 L 224.479 355.331 L 224.854 353.199 L 225.152 351.07 L 227.482 351.405 L 227.16 353.578 L 226.736 355.767 L 226.273 357.932 L 225.825 360.071 L 225.445 362.179 L 225.181 364.251 L 225.083 366.284 L 225.201 368.29 L 225.528 370.317 L 225.942 372.377 L 226.423 374.439 L 226.965 376.502 L 227.562 378.564 L 228.208 380.624 L 228.898 382.679 L 229.625 384.729 L 230.384 386.771 L 231.168 388.806 L 231.972 390.831 L 232.79 392.845 L 233.616 394.846 L 234.438 396.82 L 235.302 398.711 L 236.363 400.495 L 237.604 402.2 L 238.982 403.818 L 240.46 405.349 L 241.994 406.854 L 243.542 408.371 L 245.096 409.888 L 246.655 411.404 L 248.222 412.915 L 249.796 414.419 L 251.38 415.912 L 252.973 417.392 L 254.577 418.855 L 256.193 420.3 L 257.821 421.722 L 259.463 423.119 L 261.12 424.489 L 262.791 425.828 L 264.479 427.134 L 266.182 428.401 L 267.875 429.593 L 269.657 430.56 L 271.571 431.339 L 273.594 431.993 L 275.69 432.576 L 277.822 433.15 L 279.949 433.774 L 282.022 434.488 L 284.071 435.228 L 286.112 435.98 L 288.151 436.74 L 290.187 437.505 L 292.221 438.272 L 294.255 439.038 L 296.288 439.798 L 298.321 440.55 L 300.356 441.29 L 302.393 442.015 L 304.433 442.721 L 306.476 443.406 L 308.523 444.064 L 310.575 444.694 L 312.633 445.292 L 314.684 445.849 L 316.742 446.302 L 318.829 446.648 L 320.946 446.913 L 323.088 447.117 L 325.249 447.283 L 327.422 447.435 L 329.601 447.595 L 331.777 447.787 L 333.945 448.02 L 336.11 448.28 L 338.273 448.563 L 340.435 448.862 L 342.595 449.172 L 344.754 449.486 L 346.91 449.796 L 349.064 450.098 L 351.216 450.383 L 353.365 450.647 L 355.511 450.883 L 357.653 451.084 L 359.792 451.244 L 361.928 451.357 L 364.059 451.417 L 366.186 451.417 L 368.31 451.351 L 370.442 451.22 L 372.583 451.062 L 374.725 450.887 L 376.867 450.695 L 379.009 450.487 L 381.151 450.264 L 383.293 450.027 L 385.435 449.776 L 387.577 449.512 L 389.719 449.236 L 391.86 448.949 L 394.002 448.651 L 396.144 448.344 L 398.286 448.028 L 400.429 447.704 L 402.571 447.372 L 404.713 447.034 L 406.856 446.69 L 408.998 446.341 L 411.141 445.988 L 413.284 445.632 L 415.428 445.273 L 417.571 444.913 L 421.859 444.189 L 426.148 443.468 L 428.293 443.111 L 430.439 442.756 L 432.585 442.405 L 434.731 442.059 L 436.877 441.718 L 439.025 441.384 L 441.172 441.056 L 443.32 440.736 L 445.467 440.425" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 560.096 435.28 C 560.096 436.007 559.507 436.596 558.78 436.596 C 558.053 436.596 557.464 436.007 557.464 435.28 C 557.464 434.553 558.053 433.964 558.78 433.964 C 559.507 433.964 560.096 434.553 560.096 435.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.783 441.28 C 447.783 441.745 447.405 442.123 446.94 442.123 C 446.475 442.123 446.097 441.745 446.097 441.28 C 446.097 440.815 446.475 440.437 446.94 440.437 C 447.405 440.437 447.783 440.815 447.783 441.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.37 440.594 L 450.688 442.669 L 453.987 444.82 L 460.543 449.188 L 463.821 451.33 L 467.114 453.395 L 470.431 455.346 L 473.783 457.148 L 477.125 458.746 L 480.562 459.618 L 484.341 459.527 L 488.337 459.195 L 492.285 459.206 L 496.193 459.32 L 500.081 459.417 L 503.948 459.43 L 507.795 459.288 L 511.643 458.984 L 515.486 458.534 L 519.287 457.905 L 523 457.069 L 526.614 455.903 L 530.153 454.411 L 533.62 452.712 L 537.067 450.931 L 540.498 449.095 L 543.869 447.179 L 547.144 445.154 L 550.251 443.008 L 553.011 440.507 L 555.45 437.562 L 557.803 434.507 L 559.848 436.164 L 557.317 439.138 L 554.568 442.06 L 551.546 444.671 L 548.255 446.876 L 544.889 448.915 L 541.449 450.835 L 537.971 452.665 L 534.483 454.44 L 530.936 456.146 L 527.262 457.664 L 523.484 458.858 L 519.632 459.703 L 515.734 460.324 L 511.812 460.76 L 507.892 461.046 L 503.973 461.171 L 500.053 461.143 L 496.144 461.031 L 492.255 460.904 L 488.403 460.882 L 484.428 461.209 L 480.374 461.277 L 476.558 460.325 L 473.022 458.652 L 469.605 456.816 L 466.239 454.836 L 462.912 452.75 L 459.615 450.595 L 453.059 446.228 L 449.781 444.09 L 446.476 442.024" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 446.725 441.34 C 446.725 441.784 446.364 442.145 445.92 442.145 C 445.476 442.145 445.115 441.784 445.115 441.34 C 445.115 440.896 445.476 440.535 445.92 440.535 C 446.364 440.535 446.725 440.896 446.725 441.34" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 283.616 435.64 C 283.616 436.102 283.242 436.476 282.78 436.476 C 282.318 436.476 281.944 436.102 281.944 435.64 C 281.944 435.178 282.318 434.804 282.78 434.804 C 283.242 434.804 283.616 435.178 283.616 435.64" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 283.315 435.039 L 285.336 436.955 L 287.337 438.91 L 289.321 440.884 L 291.297 442.86 L 293.274 444.826 L 295.262 446.765 L 297.269 448.663 L 299.304 450.506 L 301.376 452.279 L 303.484 453.961 L 305.64 455.453 L 308.022 456.56 L 310.611 457.423 L 313.306 458.173 L 315.987 458.939 L 318.651 459.73 L 321.314 460.514 L 323.98 461.286 L 326.651 462.039 L 329.326 462.766 L 332.005 463.461 L 334.687 464.118 L 337.375 464.728 L 340.062 465.285 L 342.744 465.755 L 345.448 466.059 L 348.183 466.221 L 350.936 466.267 L 353.692 466.225 L 356.445 466.124 L 359.202 465.987 L 361.962 465.82 L 364.722 465.627 L 367.484 465.412 L 370.246 465.18 L 373.01 464.935 L 375.774 464.682 L 381.305 464.167 L 384.081 463.912 L 386.882 463.731 L 389.682 463.621 L 392.412 463.428 L 395.024 463.003 L 397.544 462.189 L 400.083 461.199 L 402.636 460.172 L 405.182 459.118 L 407.722 458.04 L 410.257 456.939 L 412.788 455.819 L 415.315 454.682 L 417.838 453.531 L 420.36 452.367 L 422.879 451.194 L 425.397 450.014 L 427.915 448.83 L 430.433 447.643 L 432.952 446.457 L 435.473 445.274 L 437.996 444.097 L 440.521 442.927 L 443.051 441.768 L 445.582 440.623 L 446.246 442.089 L 443.719 443.234 L 441.199 444.394 L 438.681 445.566 L 436.165 446.748 L 433.65 447.936 L 426.105 451.516 L 423.588 452.705 L 421.068 453.888 L 418.544 455.063 L 416.017 456.226 L 413.485 457.375 L 410.947 458.507 L 408.403 459.62 L 405.852 460.711 L 403.293 461.777 L 400.726 462.816 L 398.129 463.832 L 395.435 464.701 L 392.617 465.172 L 389.779 465.376 L 386.972 465.483 L 384.216 465.657 L 381.465 465.907 L 375.934 466.419 L 373.166 466.671 L 370.395 466.914 L 367.623 467.145 L 364.849 467.358 L 362.074 467.549 L 359.297 467.715 L 356.518 467.849 L 353.735 467.947 L 350.932 467.983 L 348.116 467.926 L 345.3 467.75 L 342.501 467.425 L 339.745 466.936 L 337.017 466.367 L 334.302 465.747 L 331.595 465.082 L 328.897 464.379 L 326.206 463.645 L 323.523 462.886 L 320.847 462.11 L 318.179 461.323 L 315.523 460.533 L 312.856 459.771 L 310.125 459.011 L 307.407 458.105 L 304.815 456.897 L 302.489 455.304 L 300.311 453.569 L 298.199 451.762 L 296.133 449.891 L 294.103 447.972 L 292.1 446.018 L 290.115 444.045 L 288.139 442.068 L 286.162 440.102 L 284.176 438.16 L 282.164 436.252" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 490.009 460 C 490.009 460.59 489.53 461.069 488.94 461.069 C 488.35 461.069 487.871 460.59 487.871 460 C 487.871 459.41 488.35 458.931 488.94 458.931 C 489.53 458.931 490.009 459.41 490.009 460" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 430.362 468.76 C 430.362 469.214 429.994 469.582 429.54 469.582 C 429.086 469.582 428.718 469.214 428.718 468.76 C 428.718 468.306 429.086 467.938 429.54 467.938 C 429.994 467.938 430.362 468.306 430.362 468.76" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 429.813 467.977 L 433.61 469.291 L 437.382 470.634 L 441.15 471.783 L 444.98 472.565 L 448.901 473.051 L 452.859 473.269 L 456.792 473.226 L 460.721 472.909 L 464.631 472.307 L 468.455 471.415 L 472.187 470.22 L 475.83 468.71 L 479.26 466.891 L 482.36 464.647 L 485.248 461.949 L 488.183 459.2 L 489.64 460.765 L 486.684 463.501 L 483.652 466.24 L 480.298 468.582 L 476.643 470.46 L 472.824 471.989 L 468.934 473.185 L 464.964 474.07 L 460.918 474.656 L 456.864 474.95 L 452.816 474.967 L 448.748 474.72 L 444.709 474.2 L 440.744 473.376 L 436.868 472.191 L 433.067 470.84 L 429.276 469.531" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 430.505 468.7 C 430.505 469.266 430.046 469.725 429.48 469.725 C 428.914 469.725 428.455 469.266 428.455 468.7 C 428.455 468.134 428.914 467.675 429.48 467.675 C 430.046 467.675 430.505 468.134 430.505 468.7" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 362.819 466.48 C 362.819 466.943 362.443 467.319 361.98 467.319 C 361.517 467.319 361.141 466.943 361.141 466.48 C 361.141 466.017 361.517 465.641 361.98 465.641 C 362.443 465.641 362.819 466.017 362.819 466.48" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 362.295 465.731 L 364.327 466.588 L 366.352 467.464 L 368.37 468.333 L 370.388 469.175 L 372.416 469.968 L 374.472 470.705 L 376.547 471.436 L 378.626 472.156 L 380.71 472.85 L 382.798 473.502 L 384.891 474.099 L 386.989 474.624 L 389.094 475.064 L 391.222 475.403 L 393.377 475.639 L 395.545 475.775 L 397.715 475.811 L 399.873 475.75 L 402.022 475.596 L 404.179 475.366 L 406.335 475.062 L 408.484 474.688 L 410.619 474.247 L 412.733 473.744 L 414.817 473.179 L 416.875 472.532 L 418.92 471.809 L 420.96 471.031 L 423 470.219 L 425.046 469.394 L 427.105 468.577 L 429.172 467.795 L 429.892 469.713 L 427.836 470.482 L 425.787 471.274 L 423.73 472.076 L 421.661 472.869 L 419.575 473.631 L 417.467 474.343 L 415.333 474.984 L 413.178 475.54 L 411.003 476.03 L 408.809 476.454 L 406.6 476.811 L 404.384 477.098 L 402.167 477.312 L 399.951 477.451 L 397.72 477.5 L 395.476 477.452 L 393.231 477.305 L 390.999 477.056 L 388.792 476.703 L 386.617 476.247 L 384.46 475.707 L 382.321 475.099 L 380.198 474.438 L 378.09 473.739 L 375.996 473.016 L 373.912 472.285 L 371.828 471.539 L 369.76 470.731 L 367.715 469.878 L 365.687 469.004 L 363.667 468.131 L 361.642 467.276" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 447.222 441.4 C 447.222 441.854 446.854 442.222 446.4 442.222 C 445.946 442.222 445.578 441.854 445.578 441.4 C 445.578 440.946 445.946 440.578 446.4 440.578 C 446.854 440.578 447.222 440.946 447.222 441.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 430.408 468.76 C 430.408 469.239 430.019 469.628 429.54 469.628 C 429.061 469.628 428.672 469.239 428.672 468.76 C 428.672 468.281 429.061 467.892 429.54 467.892 C 430.019 467.892 430.408 468.281 430.408 468.76" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 429.284 467.922 L 431.385 467.268 L 433.446 466.713 L 434.953 465.909 L 435.897 464.434 L 436.853 462.692 L 437.764 460.87 L 438.628 458.993 L 439.453 457.069 L 440.247 455.108 L 441.018 453.118 L 441.776 451.108 L 442.527 449.087 L 443.282 447.064 L 444.048 445.047 L 444.834 443.044 L 445.646 441.074 L 447.166 441.699 L 446.362 443.657 L 445.589 445.639 L 444.834 447.645 L 444.089 449.665 L 443.344 451.692 L 442.591 453.715 L 441.82 455.728 L 441.023 457.72 L 440.191 459.684 L 439.313 461.61 L 438.38 463.491 L 437.373 465.333 L 436.097 467.151 L 434.102 468.311 L 431.873 468.937 L 429.799 469.579" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 379.615 60.34 C 379.615 60.801 379.241 61.175 378.78 61.175 C 378.319 61.175 377.945 60.801 377.945 60.34 C 377.945 59.879 378.319 59.505 378.78 59.505 C 379.241 59.505 379.615 59.879 379.615 60.34" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 387.775 63.28 C 387.775 63.741 387.401 64.115 386.94 64.115 C 386.479 64.115 386.105 63.741 386.105 63.28 C 386.105 62.819 386.479 62.445 386.94 62.445 C 387.401 62.445 387.775 62.819 387.775 63.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 386.647 64.109 L 378.484 61.128 L 379.058 59.559 L 383.139 61.049 L 385.179 61.795 L 387.22 62.54" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 383.013 61.6 C 383.013 62.049 382.649 62.413 382.2 62.413 C 381.751 62.413 381.387 62.049 381.387 61.6 C 381.387 61.151 381.751 60.787 382.2 60.787 C 382.649 60.787 383.013 61.151 383.013 61.6" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 380.913 64.24 C 380.913 64.689 380.549 65.053 380.1 65.053 C 379.651 65.053 379.287 64.689 379.287 64.24 C 379.287 63.791 379.651 63.427 380.1 63.427 C 380.549 63.427 380.913 63.791 380.913 64.24" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 379.435 63.747 L 381.543 61.085 L 382.818 62.094 L 380.71 64.756" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 376.148 59.26 C 376.148 59.761 375.741 60.168 375.24 60.168 C 374.739 60.168 374.332 59.761 374.332 59.26 C 374.332 58.759 374.739 58.352 375.24 58.352 C 375.741 58.352 376.148 58.759 376.148 59.26" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 351.68 66.16 C 351.68 66.701 351.241 67.14 350.7 67.14 C 350.159 67.14 349.72 66.701 349.72 66.16 C 349.72 65.619 350.159 65.18 350.7 65.18 C 351.241 65.18 351.68 65.619 351.68 66.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 350.208 65.304 L 353.063 63.735 L 355.916 62.081 L 358.875 60.548 L 362 59.379 L 365.277 58.76 L 368.603 58.548 L 371.902 58.495 L 375.158 58.357 L 375.238 60.172 L 371.962 60.325 L 368.688 60.412 L 365.526 60.649 L 362.53 61.243 L 359.677 62.338 L 356.864 63.806 L 354.028 65.447 L 351.151 67.022" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 352.189 66.16 C 352.189 66.982 351.522 67.649 350.7 67.649 C 349.878 67.649 349.211 66.982 349.211 66.16 C 349.211 65.338 349.878 64.671 350.7 64.671 C 351.522 64.671 352.189 65.338 352.189 66.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 352.129 66.22 C 352.129 67.042 351.462 67.709 350.64 67.709 C 349.818 67.709 349.151 67.042 349.151 66.22 C 349.151 65.398 349.818 64.731 350.64 64.731 C 351.462 64.731 352.129 65.398 352.129 66.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 349.493 65.281 L 349.504 65.266 L 349.516 65.25 L 351.886 67.054 L 351.875 67.068 L 351.865 67.083" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 393.652 54.28 C 393.652 55.203 392.903 55.952 391.98 55.952 C 391.057 55.952 390.308 55.203 390.308 54.28 C 390.308 53.357 391.057 52.608 391.98 52.608 C 392.903 52.608 393.652 53.357 393.652 54.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 337.951 66.46 C 337.951 67.073 337.453 67.571 336.84 67.571 C 336.227 67.571 335.729 67.073 335.729 66.46 C 335.729 65.847 336.227 65.349 336.84 65.349 C 337.453 65.349 337.951 65.847 337.951 66.46" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 335.764 66.674 L 335.174 63.768 L 334.606 60.811 L 334.253 57.824 L 333.876 54.758 L 333.793 51.589 L 334.38 48.503 L 335.653 45.639 L 337.343 42.955 L 339.341 40.474 L 341.544 38.261 L 343.899 36.349 L 346.46 34.635 L 349.181 33.125 L 352.008 31.838 L 354.886 30.793 L 357.805 29.995 L 360.835 29.417 L 363.929 29.069 L 367.034 28.962 L 370.101 29.111 L 373.129 29.543 L 376.196 30.298 L 379.205 31.369 L 382.058 32.754 L 384.683 34.486 L 386.983 36.735 L 388.899 39.351 L 390.467 42.116 L 391.741 44.969 L 392.535 48.014 L 393.031 51.015 L 393.596 53.908 L 390.322 54.591 L 389.678 51.692 L 389.035 48.87 L 388.198 46.32 L 386.992 43.922 L 385.593 41.469 L 384.029 39.237 L 382.27 37.419 L 380.181 36.004 L 377.747 34.781 L 375.116 33.8 L 372.412 33.088 L 369.736 32.663 L 366.985 32.49 L 364.16 32.547 L 361.327 32.826 L 358.551 33.315 L 355.885 34.006 L 353.25 34.927 L 350.649 36.076 L 348.147 37.43 L 345.809 38.961 L 343.692 40.649 L 341.732 42.612 L 339.969 44.824 L 338.495 47.172 L 337.398 49.502 L 336.815 51.933 L 336.669 54.674 L 336.747 57.633 L 336.853 60.529 L 337.309 63.354 L 337.939 66.214" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 378.526 66.64 C 378.526 67.129 378.129 67.526 377.64 67.526 C 377.151 67.526 376.754 67.129 376.754 66.64 C 376.754 66.151 377.151 65.754 377.64 65.754 C 378.129 65.754 378.526 66.151 378.526 66.64" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 352.153 70.42 C 352.153 71.023 351.663 71.513 351.06 71.513 C 350.457 71.513 349.967 71.023 349.967 70.42 C 349.967 69.817 350.457 69.327 351.06 69.327 C 351.663 69.327 352.153 69.817 352.153 70.42" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 351.464 69.428 L 354.603 70.8 L 357.778 71.315 L 361.183 71.327 L 364.626 71.055 L 367.914 70.43 L 371.014 69.23 L 374.079 67.567 L 377.19 65.868 L 378.046 67.421 L 374.948 69.142 L 371.807 70.911 L 368.462 72.28 L 364.913 73.04 L 361.279 73.402 L 357.613 73.445 L 353.997 72.883 L 350.598 71.436" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 386.441 62.8 C 386.441 63.353 385.993 63.801 385.44 63.801 C 384.887 63.801 384.439 63.353 384.439 62.8 C 384.439 62.247 384.887 61.799 385.44 61.799 C 385.993 61.799 386.441 62.247 386.441 62.8" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 388.953 82.06 C 388.953 82.608 388.508 83.053 387.96 83.053 C 387.412 83.053 386.967 82.608 386.967 82.06 C 386.967 81.512 387.412 81.067 387.96 81.067 C 388.508 81.067 388.953 81.512 388.953 82.06" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 387.21 81.358 L 389.018 79.518 L 389.677 77.203 L 390.168 74.523 L 390.272 71.945 L 389.748 69.702 L 388.403 67.663 L 386.551 65.594 L 384.716 63.443 L 386.242 62.147 L 388.055 64.291 L 389.965 66.484 L 391.503 68.958 L 392.168 71.757 L 392.087 74.726 L 391.58 77.659 L 390.686 80.486 L 388.654 82.72" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 399.049 81.04 C 399.049 81.829 398.409 82.469 397.62 82.469 C 396.831 82.469 396.191 81.829 396.191 81.04 C 396.191 80.251 396.831 79.611 397.62 79.611 C 398.409 79.611 399.049 80.251 399.049 81.04" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 396.349 84.4 C 396.349 85.189 395.709 85.829 394.92 85.829 C 394.131 85.829 393.491 85.189 393.491 84.4 C 393.491 83.611 394.131 82.971 394.92 82.971 C 395.709 82.971 396.349 83.611 396.349 84.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 393.825 83.466 L 395.195 81.809 L 396.564 80.152 L 398.767 81.972 L 397.397 83.629 L 396.028 85.286" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 349.489 69.7 C 349.489 70.522 348.822 71.189 348 71.189 C 347.178 71.189 346.511 70.522 346.511 69.7 C 346.511 68.878 347.178 68.211 348 68.211 C 348.822 68.211 349.489 68.878 349.489 69.7" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 351.041 89.02 C 351.041 89.837 350.377 90.501 349.56 90.501 C 348.743 90.501 348.079 89.837 348.079 89.02 C 348.079 88.203 348.743 87.539 349.56 87.539 C 350.377 87.539 351.041 88.203 351.041 89.02" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 348.451 90.009 L 346.492 87.914 L 344.45 85.64 L 343.083 82.888 L 342.638 79.803 L 342.784 76.698 L 343.389 73.618 L 344.884 70.916 L 346.922 68.667 L 349.122 70.675 L 347.305 72.652 L 346.207 74.627 L 345.791 77.056 L 345.631 79.69 L 345.893 82.034 L 346.867 83.982 L 348.662 85.906 L 350.613 87.984" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 400.161 76 C 400.161 76.807 399.507 77.461 398.7 77.461 C 397.893 77.461 397.239 76.807 397.239 76 C 397.239 75.193 397.893 74.539 398.7 74.539 C 399.507 74.539 400.161 75.193 400.161 76" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 340.976 89.68 C 340.976 90.208 340.548 90.636 340.02 90.636 C 339.492 90.636 339.064 90.208 339.064 89.68 C 339.064 89.152 339.492 88.724 340.02 88.724 C 340.548 88.724 340.976 89.152 340.976 89.68" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 339.33 90.309 L 336.862 87.564 L 334.921 84.339 L 334.284 80.591 L 333.957 76.964 L 333.666 73.238 L 333.9 69.49 L 335.053 66.007 L 336.864 62.736 L 339.118 59.685 L 341.683 56.932 L 344.438 54.57 L 347.441 52.481 L 350.658 50.636 L 354.022 49.057 L 357.46 47.768 L 360.935 46.784 L 364.542 46.068 L 368.234 45.627 L 371.943 45.479 L 375.606 45.638 L 379.22 46.14 L 382.881 47.034 L 386.466 48.315 L 389.848 49.982 L 392.922 52.106 L 395.515 54.917 L 397.633 58.092 L 399.471 61.389 L 400.85 65.019 L 401.069 68.961 L 400.655 72.644 L 400.188 76.203 L 397.286 75.853 L 397.674 72.329 L 397.906 68.945 L 397.587 65.83 L 396.239 62.987 L 394.504 60.004 L 392.654 57.116 L 390.585 54.74 L 388.072 52.956 L 385.113 51.441 L 381.893 50.23 L 378.575 49.356 L 375.287 48.841 L 371.912 48.639 L 368.455 48.723 L 364.996 49.081 L 361.613 49.699 L 358.359 50.57 L 355.129 51.732 L 351.958 53.172 L 348.929 54.863 L 346.123 56.771 L 343.577 58.917 L 341.217 61.432 L 339.157 64.215 L 337.529 67.11 L 336.496 70.023 L 336.227 73.258 L 336.372 76.808 L 336.545 80.363 L 336.859 83.697 L 338.41 86.436 L 340.751 89.028" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 343.856 93.16 C 343.856 93.688 343.428 94.116 342.9 94.116 C 342.372 94.116 341.944 93.688 341.944 93.16 C 341.944 92.632 342.372 92.204 342.9 92.204 C 343.428 92.204 343.856 92.632 343.856 93.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 347.319 95.56 C 347.319 96.145 346.845 96.619 346.26 96.619 C 345.675 96.619 345.201 96.145 345.201 95.56 C 345.201 94.975 345.675 94.501 346.26 94.501 C 346.845 94.501 347.319 94.975 347.319 95.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 345.891 96.53 L 343.694 95.635 L 342.161 93.791 L 343.646 92.585 L 344.785 94.032 L 346.587 94.53" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 97.069 152.08 C 97.069 153.035 96.295 153.809 95.34 153.809 C 94.385 153.809 93.611 153.035 93.611 152.08 C 93.611 151.125 94.385 150.351 95.34 150.351 C 96.295 150.351 97.069 151.125 97.069 152.08" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 42.049 166.9 C 42.049 167.855 41.275 168.629 40.32 168.629 C 39.365 168.629 38.591 167.855 38.591 166.9 C 38.591 165.945 39.365 165.171 40.32 165.171 C 41.275 165.171 42.049 165.945 42.049 166.9" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 39.901 165.254 L 94.888 150.404 L 95.789 153.743 L 40.803 168.593" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 111.998 183.76 C 111.998 184.344 111.524 184.818 110.94 184.818 C 110.356 184.818 109.882 184.344 109.882 183.76 C 109.882 183.176 110.356 182.702 110.94 182.702 C 111.524 182.702 111.998 183.176 111.998 183.76" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 113.586 184.18 C 113.586 184.813 113.073 185.326 112.44 185.326 C 111.807 185.326 111.294 184.813 111.294 184.18 C 111.294 183.547 111.807 183.034 112.44 183.034 C 113.073 183.034 113.586 183.547 113.586 184.18" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 111.972 185.2 L 111.433 184.898 L 110.818 184.802 L 111.097 182.704 L 112.002 182.81 L 112.849 183.082" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 93.105 184.42 C 93.105 185.041 92.601 185.545 91.98 185.545 C 91.359 185.545 90.855 185.041 90.855 184.42 C 90.855 183.799 91.359 183.295 91.98 183.295 C 92.601 183.295 93.105 183.799 93.105 184.42" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 122.091 188.92 C 122.091 189.843 121.343 190.591 120.42 190.591 C 119.497 190.591 118.749 189.843 118.749 188.92 C 118.749 187.997 119.497 187.249 120.42 187.249 C 121.343 187.249 122.091 187.997 122.091 188.92" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 118.717 188.829 L 118.97 185.474 L 119.228 182.118 L 119.49 178.763 L 119.752 175.41 L 120.013 172.057 L 120.27 168.705 L 120.521 165.353 L 120.761 162.002 L 120.99 158.652 L 121.168 155.299 L 121.223 152.161 L 120.741 149.579 L 119.134 147.515 L 116.806 145.839 L 114.151 144.607 L 111.236 144.009 L 108.24 143.994 L 105.194 144.539 L 102.259 145.507 L 99.583 146.945 L 97.371 148.589 L 96.886 151.228 L 96.382 154.429 L 95.921 157.71 L 95.505 161.021 L 95.123 164.356 L 94.768 167.709 L 94.431 171.075 L 94.103 174.449 L 93.775 177.824 L 93.438 181.195 L 93.093 184.551 L 90.854 184.331 L 91.169 180.982 L 91.434 177.621 L 91.674 174.247 L 91.9 170.866 L 92.127 167.482 L 92.368 164.1 L 92.637 160.725 L 92.949 157.362 L 93.315 154.016 L 93.761 150.646 L 94.715 146.957 L 97.684 144.19 L 100.882 142.397 L 104.294 141.172 L 107.882 140.433 L 111.564 140.34 L 115.284 140.997 L 118.737 142.48 L 121.865 144.726 L 124.31 148.041 L 124.95 151.929 L 124.569 155.523 L 124.297 158.879 L 124.055 162.238 L 123.808 165.595 L 123.558 168.952 L 123.306 172.308 L 123.053 175.663 L 122.8 179.017 L 122.547 182.371 L 122.297 185.723 L 122.051 189.076" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 124.267 163.78 C 124.267 164.877 123.377 165.767 122.28 165.767 C 121.183 165.767 120.293 164.877 120.293 163.78 C 120.293 162.683 121.183 161.793 122.28 161.793 C 123.377 161.793 124.267 162.683 124.267 163.78" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 145.507 196.84 C 145.507 197.937 144.617 198.827 143.52 198.827 C 142.423 198.827 141.533 197.937 141.533 196.84 C 141.533 195.743 142.423 194.853 143.52 194.853 C 144.617 194.853 145.507 195.743 145.507 196.84" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 141.871 197.915 L 140.54 195.846 L 139.208 193.778 L 137.877 191.709 L 136.545 189.641 L 135.214 187.572 L 133.882 185.504 L 132.551 183.435 L 131.219 181.367 L 129.888 179.298 L 128.556 177.23 L 125.893 173.093 L 124.561 171.025 L 123.23 168.956 L 121.898 166.888 L 120.567 164.819 L 123.908 162.669 L 133.228 177.148 L 134.56 179.216 L 135.891 181.285 L 137.223 183.353 L 138.554 185.422 L 139.886 187.49 L 145.212 195.764" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 41.822 166.9 C 41.822 167.729 41.149 168.402 40.32 168.402 C 39.491 168.402 38.818 167.729 38.818 166.9 C 38.818 166.071 39.491 165.398 40.32 165.398 C 41.149 165.398 41.822 166.071 41.822 166.9" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 36.062 202.18 C 36.062 203.009 35.389 203.682 34.56 203.682 C 33.731 203.682 33.058 203.009 33.058 202.18 C 33.058 201.351 33.731 200.678 34.56 200.678 C 35.389 200.678 36.062 201.351 36.062 202.18" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 33.136 201.968 L 34.568 193.148 L 34.926 190.943 L 35.642 186.533 L 35.999 184.328 L 36.357 182.123 L 36.715 179.918 L 37.073 177.713 L 37.431 175.507 L 37.789 173.302 L 38.147 171.097 L 38.505 168.892 L 38.863 166.687 L 41.828 167.169 L 41.47 169.374 L 41.112 171.579 L 38.606 187.014 L 38.249 189.219 L 37.175 195.834 L 36.101 202.449" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 13.717 204.94 C 13.717 205.557 13.217 206.057 12.6 206.057 C 11.983 206.057 11.483 205.557 11.483 204.94 C 11.483 204.323 11.983 203.823 12.6 203.823 C 13.217 203.823 13.717 204.323 13.717 204.94" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 42.289 166.9 C 42.289 167.987 41.407 168.869 40.32 168.869 C 39.233 168.869 38.351 167.987 38.351 166.9 C 38.351 165.813 39.233 164.931 40.32 164.931 C 41.407 164.931 42.289 165.813 42.289 166.9" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 39.023 168.382 L 36.401 165.921 L 33.41 164.574 L 30.048 164.099 L 26.604 164.435 L 23.42 165.53 L 21.089 167.448 L 20.447 170.785 L 19.669 174.569 L 18.896 178.375 L 18.13 182.186 L 17.372 186 L 16.619 189.818 L 15.874 193.638 L 15.135 197.461 L 14.401 201.285 L 13.683 205.11 L 11.485 204.706 L 12.172 200.878 L 12.83 197.044 L 13.474 193.205 L 14.11 189.364 L 14.744 185.523 L 15.383 181.681 L 16.032 177.841 L 16.698 174.004 L 17.391 170.154 L 18.425 165.877 L 21.702 162.697 L 25.799 161.071 L 30.067 160.501 L 34.4 160.974 L 38.486 162.691 L 41.66 165.459" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 84.456 194.86 C 84.456 195.377 84.037 195.796 83.52 195.796 C 83.003 195.796 82.584 195.377 82.584 194.86 C 82.584 194.343 83.003 193.924 83.52 193.924 C 84.037 193.924 84.456 194.343 84.456 194.86" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 42.996 205.48 C 42.996 205.997 42.577 206.416 42.06 206.416 C 41.543 206.416 41.124 205.997 41.124 205.48 C 41.124 204.963 41.543 204.544 42.06 204.544 C 42.577 204.544 42.996 204.963 42.996 205.48" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 41.813 204.601 L 83.285 193.941 L 83.751 195.754 L 42.279 206.414" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 88.532 202.48 C 88.532 203.061 88.061 203.532 87.48 203.532 C 86.899 203.532 86.428 203.061 86.428 202.48 C 86.428 201.899 86.899 201.428 87.48 201.428 C 88.061 201.428 88.532 201.899 88.532 202.48" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 48.872 212.2 C 48.872 212.781 48.401 213.252 47.82 213.252 C 47.239 213.252 46.768 212.781 46.768 212.2 C 46.768 211.619 47.239 211.148 47.82 211.148 C 48.401 211.148 48.872 211.619 48.872 212.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 47.575 211.198 L 87.235 201.437 L 87.738 203.479 L 48.078 213.241" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 59.373 209.74 C 59.373 210.586 58.686 211.273 57.84 211.273 C 56.994 211.273 56.307 210.586 56.307 209.74 C 56.307 208.894 56.994 208.207 57.84 208.207 C 58.686 208.207 59.373 208.894 59.373 209.74" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 57.153 226.12 C 57.153 226.966 56.466 227.653 55.62 227.653 C 54.774 227.653 54.087 226.966 54.087 226.12 C 54.087 225.274 54.774 224.587 55.62 224.587 C 56.466 224.587 57.153 225.274 57.153 226.12" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 54.086 225.908 L 54.646 221.818 L 54.926 219.773 L 55.206 217.728 L 55.486 215.683 L 55.766 213.638 L 56.046 211.593 L 56.326 209.547 L 59.365 209.963 L 59.085 212.008 L 58.805 214.054 L 58.525 216.099 L 58.245 218.144 L 57.965 220.189 L 57.685 222.234 L 57.405 224.279 L 57.125 226.324" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 42.173 224.2 C 42.173 224.859 41.639 225.393 40.98 225.393 C 40.321 225.393 39.787 224.859 39.787 224.2 C 39.787 223.541 40.321 223.007 40.98 223.007 C 41.639 223.007 42.173 223.541 42.173 224.2" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 45.893 228.76 C 45.893 229.419 45.359 229.953 44.7 229.953 C 44.041 229.953 43.507 229.419 43.507 228.76 C 43.507 228.101 44.041 227.567 44.7 227.567 C 45.359 227.567 45.893 228.101 45.893 228.76" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 43.726 229.459 L 40.078 224.957 L 41.932 223.454 L 43.756 225.706 L 45.581 227.957" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 47.253 221.56 C 47.253 222.406 46.566 223.093 45.72 223.093 C 44.874 223.093 44.187 222.406 44.187 221.56 C 44.187 220.714 44.874 220.027 45.72 220.027 C 46.566 220.027 47.253 220.714 47.253 221.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 46.173 228.7 C 46.173 229.546 45.486 230.233 44.64 230.233 C 43.794 230.233 43.107 229.546 43.107 228.7 C 43.107 227.854 43.794 227.167 44.64 227.167 C 45.486 227.167 46.173 227.854 46.173 228.7" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 43.137 228.484 L 43.663 224.923 L 44.189 221.363 L 47.222 221.811 L 46.696 225.371 L 46.17 228.932" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 56.56 226.12 C 56.56 226.639 56.139 227.06 55.62 227.06 C 55.101 227.06 54.68 226.639 54.68 226.12 C 54.68 225.601 55.101 225.18 55.62 225.18 C 56.139 225.18 56.56 225.601 56.56 226.12" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 45.58 228.7 C 45.58 229.219 45.159 229.64 44.64 229.64 C 44.121 229.64 43.7 229.219 43.7 228.7 C 43.7 228.181 44.121 227.76 44.64 227.76 C 45.159 227.76 45.58 228.181 45.58 228.7" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 44.439 227.794 L 55.388 225.204 L 55.821 227.032 L 44.871 229.623" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 33.556 228.82 C 33.556 229.259 33.199 229.616 32.76 229.616 C 32.321 229.616 31.964 229.259 31.964 228.82 C 31.964 228.38 32.321 228.024 32.76 228.024 C 33.199 228.024 33.556 228.38 33.556 228.82" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 35.416 231.1 C 35.416 231.539 35.059 231.896 34.62 231.896 C 34.181 231.896 33.824 231.539 33.824 231.1 C 33.824 230.66 34.181 230.304 34.62 230.304 C 35.059 230.304 35.416 230.66 35.416 231.1" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 34.015 231.564 L 33.095 230.422 L 32.174 229.28 L 33.414 228.281 L 34.335 229.423 L 35.255 230.565" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 145.142 196.84 C 145.142 197.702 144.442 198.402 143.58 198.402 C 142.718 198.402 142.018 197.702 142.018 196.84 C 142.018 195.978 142.718 195.278 143.58 195.278 C 144.442 195.278 145.142 195.978 145.142 196.84" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 143.342 234.28 C 143.342 235.142 142.642 235.842 141.78 235.842 C 140.918 235.842 140.218 235.142 140.218 234.28 C 140.218 233.418 140.918 232.718 141.78 232.718 C 142.642 232.718 143.342 233.418 143.342 234.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 140.174 234.193 L 140.287 231.854 L 140.4 229.515 L 140.513 227.176 L 140.626 224.838 L 140.739 222.499 L 140.852 220.16 L 140.966 217.821 L 141.079 215.482 L 141.192 213.143 L 141.305 210.804 L 141.531 206.126 L 141.644 203.788 L 141.757 201.449 L 141.871 199.11 L 141.984 196.771 L 145.104 196.922 L 144.991 199.261 L 144.877 201.6 L 144.764 203.938 L 144.651 206.277 L 144.425 210.955 L 144.312 213.294 L 144.199 215.633 L 144.086 217.972 L 143.972 220.311 L 143.859 222.65 L 143.746 224.989 L 143.633 227.327 L 143.52 229.666 L 143.407 232.005 L 143.294 234.344" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 120.534 204.64 C 120.534 205.299 119.999 205.834 119.34 205.834 C 118.681 205.834 118.146 205.299 118.146 204.64 C 118.146 203.981 118.681 203.446 119.34 203.446 C 119.999 203.446 120.534 203.981 120.534 204.64" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 140.814 234.4 C 140.814 235.059 140.279 235.594 139.62 235.594 C 138.961 235.594 138.426 235.059 138.426 234.4 C 138.426 233.741 138.961 233.206 139.62 233.206 C 140.279 233.206 140.814 233.741 140.814 234.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 138.674 235.111 L 133.594 227.659 L 132.325 225.796 L 127.245 218.344 L 124.706 214.617 L 118.356 205.302 L 120.329 203.957 L 122.868 207.684 L 130.488 218.862 L 131.757 220.725 L 134.297 224.451 L 135.567 226.315 L 138.107 230.041 L 139.376 231.904 L 140.646 233.767" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 21.654 227.62 C 21.654 228.246 21.146 228.754 20.52 228.754 C 19.894 228.754 19.386 228.246 19.386 227.62 C 19.386 226.994 19.894 226.486 20.52 226.486 C 21.146 226.486 21.654 226.994 21.654 227.62" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 20.454 234.94 C 20.454 235.566 19.946 236.074 19.32 236.074 C 18.694 236.074 18.186 235.566 18.186 234.94 C 18.186 234.314 18.694 233.806 19.32 233.806 C 19.946 233.806 20.454 234.314 20.454 234.94" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 18.15 234.748 L 18.78 231.095 L 19.41 227.441 L 21.644 227.827 L 20.384 235.133" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 35.556 231.04 C 35.556 231.556 35.136 231.976 34.62 231.976 C 34.104 231.976 33.684 231.556 33.684 231.04 C 33.684 230.524 34.104 230.104 34.62 230.104 C 35.136 230.104 35.556 230.524 35.556 231.04" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 20.196 234.94 C 20.196 235.456 19.776 235.876 19.26 235.876 C 18.744 235.876 18.324 235.456 18.324 234.94 C 18.324 234.424 18.744 234.004 19.26 234.004 C 19.776 234.004 20.196 234.424 20.196 234.94" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 19.039 234.034 L 34.405 230.158 L 34.863 231.973 L 19.497 235.848" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 56.814 226.12 C 56.814 226.779 56.279 227.314 55.62 227.314 C 54.961 227.314 54.426 226.779 54.426 226.12 C 54.426 225.461 54.961 224.926 55.62 224.926 C 56.279 224.926 56.814 225.461 56.814 226.12" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 65.574 237.28 C 65.574 237.939 65.039 238.474 64.38 238.474 C 63.721 238.474 63.186 237.939 63.186 237.28 C 63.186 236.621 63.721 236.086 64.38 236.086 C 65.039 236.086 65.574 236.621 65.574 237.28" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 63.459 238.045 L 61.261 235.248 L 54.668 226.856 L 56.545 225.382 L 58.743 228.179 L 60.94 230.976 L 65.336 236.57" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 107.177 212.38 C 107.177 212.82 106.82 213.177 106.38 213.177 C 105.94 213.177 105.583 212.82 105.583 212.38 C 105.583 211.94 105.94 211.583 106.38 211.583 C 106.82 211.583 107.177 211.94 107.177 212.38" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 126.317 239.26 C 126.317 239.7 125.96 240.057 125.52 240.057 C 125.08 240.057 124.723 239.7 124.723 239.26 C 124.723 238.82 125.08 238.463 125.52 238.463 C 125.96 238.463 126.317 238.82 126.317 239.26" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 124.856 239.699 L 122.464 236.341 L 121.269 234.662 L 115.289 226.267 L 114.093 224.587 L 110.505 219.55 L 109.31 217.871 L 105.722 212.834 L 107.02 211.909 L 110.608 216.946 L 112.999 220.305 L 121.371 232.058 L 123.762 235.417 L 126.154 238.775" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 145.359 196.84 C 145.359 197.822 144.562 198.619 143.58 198.619 C 142.598 198.619 141.801 197.822 141.801 196.84 C 141.801 195.858 142.598 195.061 143.58 195.061 C 144.562 195.061 145.359 195.858 145.359 196.84" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 159.656 240.46 C 159.656 241.385 158.905 242.136 157.98 242.136 C 157.055 242.136 156.304 241.385 156.304 240.46 C 156.304 239.535 157.055 238.784 157.98 238.784 C 158.905 238.784 159.656 239.535 159.656 240.46" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 156.314 240.403 L 156.431 236.939 L 156.557 233.474 L 156.689 230.01 L 156.821 226.547 L 156.951 223.085 L 157.075 219.626 L 157.187 216.168 L 157.286 212.713 L 157.366 209.26 L 157.293 205.912 L 157.042 203.114 L 155.35 201.194 L 152.88 199.648 L 150.03 198.631 L 147.01 198.279 L 143.738 198.612 L 143.361 195.073 L 147.001 194.671 L 150.821 194.988 L 154.52 196.189 L 157.918 198.293 L 160.531 201.687 L 160.913 205.767 L 160.697 209.337 L 160.6 212.804 L 160.493 216.271 L 160.379 219.738 L 160.26 223.203 L 160.138 226.668 L 160.015 230.131 L 159.893 233.593 L 159.776 237.053 L 159.664 240.514" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 124.25 247.3 C 124.25 247.791 123.851 248.19 123.36 248.19 C 122.869 248.19 122.47 247.791 122.47 247.3 C 122.47 246.809 122.869 246.41 123.36 246.41 C 123.851 246.41 124.25 246.809 124.25 247.3" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 116.57 250.72 C 116.57 251.211 116.171 251.61 115.68 251.61 C 115.189 251.61 114.79 251.211 114.79 250.72 C 114.79 250.229 115.189 249.83 115.68 249.83 C 116.171 249.83 116.57 250.229 116.57 250.72" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 115.285 249.913 L 123.015 246.512 L 123.732 248.142 L 117.934 250.692 L 116.002 251.543" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 128.959 253.48 C 128.959 254.087 128.467 254.579 127.86 254.579 C 127.253 254.579 126.761 254.087 126.761 253.48 C 126.761 252.873 127.253 252.381 127.86 252.381 C 128.467 252.381 128.959 252.873 128.959 253.48" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 123.079 256.06 C 123.079 256.667 122.587 257.159 121.98 257.159 C 121.373 257.159 120.881 256.667 120.881 256.06 C 120.881 255.453 121.373 254.961 121.98 254.961 C 122.587 254.961 123.079 255.453 123.079 256.06" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 121.515 255.034 L 127.418 252.503 L 128.284 254.522 L 122.381 257.054" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 20.057 234.94 C 20.057 235.38 19.7 235.737 19.26 235.737 C 18.82 235.737 18.463 235.38 18.463 234.94 C 18.463 234.5 18.82 234.143 19.26 234.143 C 19.7 234.143 20.057 234.5 20.057 234.94" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 53.477 273.88 C 53.477 274.32 53.12 274.677 52.68 274.677 C 52.24 274.677 51.883 274.32 51.883 273.88 C 51.883 273.44 52.24 273.083 52.68 273.083 C 53.12 273.083 53.477 273.44 53.477 273.88" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 52.068 274.413 L 47.893 269.544 L 43.717 264.676 L 41.63 262.241 L 37.454 257.373 L 33.279 252.504 L 29.103 247.636 L 27.016 245.201 L 22.84 240.333 L 20.753 237.898 L 18.665 235.464 L 19.875 234.426 L 24.05 239.295 L 53.278 273.375" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 57.874 272.92 C 57.874 273.502 57.402 273.974 56.82 273.974 C 56.238 273.974 55.766 273.502 55.766 272.92 C 55.766 272.338 56.238 271.866 56.82 271.866 C 57.402 271.866 57.874 272.338 57.874 272.92" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 53.734 273.88 C 53.734 274.462 53.262 274.934 52.68 274.934 C 52.098 274.934 51.626 274.462 51.626 273.88 C 51.626 273.298 52.098 272.826 52.68 272.826 C 53.262 272.826 53.734 273.298 53.734 273.88" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 52.438 272.872 L 54.504 272.39 L 56.571 271.909 L 57.049 273.961 L 52.916 274.924" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 354.258 89.74 C 354.258 90.644 353.524 91.378 352.62 91.378 C 351.716 91.378 350.982 90.644 350.982 89.74 C 350.982 88.836 351.716 88.102 352.62 88.102 C 353.524 88.102 354.258 88.836 354.258 89.74" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 350.885 91.66 C 350.885 92.292 350.372 92.805 349.74 92.805 C 349.108 92.805 348.595 92.292 348.595 91.66 C 348.595 91.028 349.108 90.515 349.74 90.515 C 350.372 90.515 350.885 91.028 350.885 91.66" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 348.598 91.737 L 348.332 88.312 L 348.059 84.886 L 347.782 81.459 L 347.504 78.029 L 347.229 74.6 L 346.959 71.171 L 346.455 67.585 L 347.94 63.504 L 352.065 64.77 L 352.903 68.912 L 353.17 72.348 L 353.393 75.799 L 353.591 79.254 L 353.785 82.707 L 353.995 86.148 L 354.248 89.577 L 350.982 89.831 L 350.701 86.394 L 350.418 82.945 L 350.132 79.5 L 349.832 76.068 L 349.512 72.659 L 349.163 69.281 L 349.28 66.671 L 348.686 65.447 L 349.226 67.75 L 349.199 71.008 L 349.448 74.427 L 349.722 77.849 L 350.012 81.273 L 350.307 84.7 L 350.6 88.128 L 350.882 91.554" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 143.462 263.8 C 143.462 264.464 142.924 265.002 142.26 265.002 C 141.596 265.002 141.058 264.464 141.058 263.8 C 141.058 263.136 141.596 262.598 142.26 262.598 C 142.924 262.598 143.462 263.136 143.462 263.8" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 140.08 263.56 C 140.08 264.013 139.713 264.38 139.26 264.38 C 138.807 264.38 138.44 264.013 138.44 263.56 C 138.44 263.107 138.807 262.74 139.26 262.74 C 139.713 262.74 140.08 263.107 140.08 263.56" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 138.705 264.168 L 136.306 262.108 L 133.85 260.084 L 131.377 258.057 L 128.933 255.996 L 126.567 253.872 L 124.245 251.655 L 122.124 248.957 L 121.109 245.398 L 121.76 241.96 L 123.75 238.826 L 126.321 236.561 L 129.32 234.869 L 132.498 233.666 L 135.716 232.909 L 139.038 232.504 L 142.371 232.438 L 145.66 232.707 L 148.969 233.331 L 152.198 234.321 L 155.272 235.73 L 158.217 237.723 L 160.699 240.308 L 162.32 243.73 L 162.636 247.606 L 161.292 251.11 L 158.916 253.946 L 156.318 256.035 L 153.677 257.88 L 150.978 259.614 L 148.266 261.298 L 145.588 262.99 L 142.981 264.766 L 141.6 262.798 L 144.176 260.941 L 146.755 259.07 L 149.297 257.187 L 151.767 255.275 L 154.132 253.32 L 156.288 251.368 L 158.043 249.19 L 158.958 247.056 L 158.725 244.697 L 157.656 242.393 L 155.845 240.506 L 153.479 238.836 L 150.91 237.582 L 148.106 236.642 L 145.169 236.007 L 142.226 235.683 L 139.219 235.662 L 136.215 235.946 L 133.337 236.543 L 130.523 237.528 L 127.938 238.898 L 125.85 240.65 L 124.324 243.003 L 123.765 245.391 L 124.207 248.1 L 125.632 250.525 L 127.668 252.723 L 129.961 254.819 L 132.376 256.85 L 134.854 258.854 L 137.34 260.868 L 139.768 262.92" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 142.496 264.16 C 142.496 264.688 142.068 265.116 141.54 265.116 C 141.012 265.116 140.584 264.688 140.584 264.16 C 140.584 263.632 141.012 263.204 141.54 263.204 C 142.068 263.204 142.496 263.632 142.496 264.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 142.496 264.16 C 142.496 264.687 142.067 265.116 141.54 265.116 C 141.013 265.116 140.584 264.687 140.584 264.16 C 140.584 263.633 141.013 263.204 141.54 263.204 C 142.067 263.204 142.496 263.633 142.496 264.16" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 140.821 264.697 L 140.159 262.137 L 142.342 263.538 L 140.823 264.697 L 140.049 262.221 L 142.341 263.539" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 69.319 207.22 C 69.319 207.827 68.827 208.319 68.22 208.319 C 67.613 208.319 67.121 207.827 67.121 207.22 C 67.121 206.613 67.613 206.121 68.22 206.121 C 68.827 206.121 69.319 206.613 69.319 207.22" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 61.159 271.3 C 61.159 271.907 60.667 272.399 60.06 272.399 C 59.453 272.399 58.961 271.907 58.961 271.3 C 58.961 270.693 59.453 270.201 60.06 270.201 C 60.667 270.201 61.159 270.693 61.159 271.3" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 59.009 271.171 L 59.516 267.165 L 60.022 263.159 L 60.529 259.153 L 61.035 255.147 L 61.542 251.14 L 62.048 247.134 L 63.062 239.122 L 63.568 235.116 L 64.075 231.11 L 64.581 227.103 L 65.595 219.091 L 66.101 215.085 L 66.608 211.079 L 67.114 207.072 L 69.295 207.348 L 68.788 211.354 L 68.282 215.361 L 67.268 223.373 L 66.762 227.379 L 66.255 231.385 L 65.749 235.392 L 65.242 239.398 L 64.735 243.404 L 64.229 247.41 L 63.722 251.416 L 63.216 255.422 L 62.709 259.429 L 62.202 263.435 L 61.696 267.441 L 61.189 271.447" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 118.984 227.8 C 118.984 228.73 118.23 229.484 117.3 229.484 C 116.37 229.484 115.616 228.73 115.616 227.8 C 115.616 226.87 116.37 226.116 117.3 226.116 C 118.23 226.116 118.984 226.87 118.984 227.8" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 115.384 276.4 C 115.384 277.33 114.63 278.084 113.7 278.084 C 112.77 278.084 112.016 277.33 112.016 276.4 C 112.016 275.47 112.77 274.716 113.7 274.716 C 114.63 274.716 115.384 275.47 115.384 276.4" transform="matrix(1,0,0,-1,0,478)"/>
+<path d="M 112.073 276.27 L 112.297 273.231 L 112.521 270.192 L 112.744 267.153 L 112.968 264.114 L 113.192 261.074 L 113.416 258.035 L 113.639 254.996 L 113.863 251.957 L 114.087 248.918 L 114.311 245.879 L 114.534 242.84 L 114.758 239.801 L 114.982 236.761 L 115.205 233.722 L 115.653 227.644 L 119.012 227.891 L 118.789 230.93 L 118.565 233.97 L 118.341 237.009 L 118.117 240.048 L 117.894 243.087 L 117.67 246.126 L 117.446 249.165 L 117.223 252.204 L 116.999 255.244 L 116.775 258.283 L 116.551 261.322 L 116.328 264.361 L 116.104 267.4 L 115.88 270.439 L 115.656 273.478 L 115.433 276.517" transform="matrix(1,0,0,-1,0,478)"/>
+<symbol id="font_1_2">
+<path d="M .2265625 .93310549 C .17545574 .8338216 .14225261 .7607422 .12695313 .7138672 C .10384115 .6425781 .092285159 .5602214 .092285159 .46679688 C .092285159 .37239585 .10546875 .2861328 .13183594 .20800781 C .14811199 .15983074 .18017578 .09049479 .22802735 0 L .16894531 0 C .12141927 .07421875 .09195963 .12158203 .080566409 .14208985 C .06917318 .16259766 .056803388 .19042969 .04345703 .22558594 C .025227866 .27376304 .012532552 .3251953 .0053710939 .3798828 C .0017903646 .40820313 0 .43522135 0 .4609375 C 0 .5572917 .015136719 .6430664 .045410158 .7182617 C .06461588 .7661133 .104654949 .83772787 .16552735 .93310549 L .2265625 .93310549 Z"/>
+</symbol>
+<symbol id="font_1_8">
+<path d="M .23730469 .55322268 C .29622398 .55322268 .34407554 .5388997 .38085938 .5102539 C .41796876 .48160807 .44026695 .43229167 .4477539 .3623047 L .3623047 .3623047 C .35709635 .39453126 .34521485 .42122398 .32666017 .4423828 C .30810548 .4638672 .2783203 .47460938 .23730469 .47460938 C .18131511 .47460938 .14127605 .44726563 .1171875 .39257813 C .1015625 .35709635 .09375 .3133138 .09375 .26123048 C .09375 .20882161 .10481771 .16471355 .12695313 .12890625 C .14908855 .09309896 .18391927 .07519531 .23144531 .07519531 C .26790367 .07519531 .29671226 .08626302 .3178711 .10839844 C .33935548 .13085938 .35416667 .16145833 .3623047 .20019531 L .4477539 .20019531 C .43798829 .13085938 .41357423 .080078128 .37451173 .047851564 C .33544923 .015950522 .28548179 0 .22460938 0 C .15625 0 .10172526 .024902344 .061035158 .07470703 C .020345053 .12483724 0 .18733724 0 .26220704 C 0 .3540039 .022298178 .42545573 .06689453 .4765625 C .11149088 .52766928 .16829427 .55322268 .23730469 .55322268 M .22363281 .55078127 L .22363281 .55078127 Z"/>
+</symbol>
+<symbol id="font_1_3">
+<path d="M .0014648438 0 C .053222658 .10091146 .08658854 .17447917 .1015625 .22070313 C .12434896 .2906901 .13574219 .37272135 .13574219 .46679688 C .13574219 .5608724 .122558597 .64697268 .096191409 .72509768 C .07991537 .7732747 .047851564 .84261068 0 .93310549 L .05908203 .93310549 C .10921224 .85302737 .13948567 .80354818 .14990235 .78466799 C .16064453 .7661133 .17220052 .74039718 .18457031 .70751956 C .20019531 .6668294 .21126302 .6266276 .21777344 .58691409 C .22460938 .5472005 .22802735 .50895187 .22802735 .47216798 C .22802735 .3758138 .21272786 .2898763 .1821289 .21435547 C .16292317 .16585286 .123046878 .09440104 .0625 0 L .0014648438 0 Z"/>
+</symbol>
+<symbol id="font_1_1">
+<path d="M 0 0 Z"/>
+</symbol>
+<symbol id="font_1_7">
+<path d="M .27197267 .4140625 C .31298829 .4140625 .3448893 .41975913 .36767579 .43115235 C .40348307 .449056 .42138673 .48128257 .42138673 .52783206 C .42138673 .57470706 .40234376 .60628256 .3642578 .6225586 C .34277345 .63167318 .3108724 .63623049 .2685547 .63623049 L .095214847 .63623049 L .095214847 .4140625 L .27197267 .4140625 M .3046875 .08300781 C .3642578 .08300781 .40673829 .100260417 .4321289 .13476563 C .44807945 .15657552 .4560547 .1829427 .4560547 .21386719 C .4560547 .26595054 .43277995 .30143229 .38623048 .3203125 C .36149089 .33040367 .32877604 .33544923 .28808595 .33544923 L .095214847 .33544923 L .095214847 .08300781 L .3046875 .08300781 M 0 .71728518 L .30810548 .71728518 C .39208985 .71728518 .4518229 .69222006 .4873047 .64208987 C .508138 .61246749 .5185547 .5782878 .5185547 .5395508 C .5185547 .49430339 .5056966 .457194 .47998048 .42822267 C .46663413 .4129232 .44742839 .39892579 .42236329 .38623048 C .45914714 .37223307 .48665367 .3564453 .5048828 .3388672 C .5371094 .3076172 .55322268 .2644857 .55322268 .20947266 C .55322268 .1632487 .538737 .12141927 .5097656 .083984378 C .46647135 .027994791 .3976237 0 .30322267 0 L 0 0 L 0 .71728518 Z"/>
+</symbol>
+<symbol id="font_1_9">
+<path d="M .24707031 .55322268 C .2841797 .55322268 .32014976 .5444336 .35498048 .52685549 C .3898112 .50960287 .41634117 .48714195 .4345703 .45947267 C .45214845 .43310548 .4638672 .40234376 .46972657 .3671875 C .4749349 .34309898 .47753907 .3046875 .47753907 .25195313 L .09423828 .25195313 C .09586588 .19889324 .10839844 .15625 .13183594 .12402344 C .15527344 .0921224 .19156902 .076171878 .24072266 .076171878 C .2866211 .076171878 .3232422 .091308597 .35058595 .12158203 C .36621095 .13916016 .37727867 .1595052 .38378907 .18261719 L .47021485 .18261719 C .4679362 .16341146 .46028648 .14192708 .44726563 .11816406 C .4345703 .09472656 .4202474 .075520839 .40429688 .060546876 C .37760417 .034505208 .3445638 .016927084 .30517579 .0078125 C .28401695 .0026041668 .26009117 0 .23339844 0 C .16829427 0 .11311849 .02360026 .067871097 .07080078 C .022623698 .11832682 0 .18473308 0 .27001954 C 0 .3540039 .022786459 .42220054 .068359378 .47460938 C .11393229 .52701827 .17350261 .55322268 .24707031 .55322268 M .38720704 .32177735 C .3836263 .35986329 .37532554 .39029948 .3623047 .41308595 C .33821617 .45540367 .2980143 .4765625 .24169922 .4765625 C .20133464 .4765625 .16748047 .46191407 .14013672 .4326172 C .11279297 .40364585 .09830729 .36669923 .09667969 .32177735 L .38720704 .32177735 M .23876953 .5541992 L .23876953 .5541992 Z"/>
+</symbol>
+<symbol id="font_1_a">
+<path d="M 0 .5229492 L .083496097 .5229492 L .083496097 .4326172 C .09033203 .4501953 .10709635 .47151695 .13378906 .49658204 C .16048177 .52197268 .19124349 .53466799 .22607422 .53466799 C .22770183 .53466799 .23046875 .5345052 .234375 .5341797 C .23828125 .5338542 .24495442 .5332031 .25439454 .53222659 L .25439454 .43945313 C .2491862 .4404297 .24430339 .44108073 .2397461 .44140626 C .23551433 .44173179 .23079427 .44189454 .22558594 .44189454 C .18131511 .44189454 .14729817 .42757163 .123535159 .39892579 C .09977213 .37060548 .087890628 .33789063 .087890628 .30078126 L .087890628 0 L 0 0 L 0 .5229492 Z"/>
+</symbol>
+<symbol id="font_1_b">
+<path d="M .07080078 .6772461 L .15966797 .6772461 L .15966797 .53125 L .24316406 .53125 L .24316406 .45947267 L .15966797 .45947267 L .15966797 .11816406 C .15966797 .0999349 .16585286 .08772787 .17822266 .08154297 C .1850586 .07796224 .19645183 .076171878 .21240235 .076171878 C .21663411 .076171878 .2211914 .076171878 .22607422 .076171878 C .23095703 .0764974 .23665364 .07698568 .24316406 .07763672 L .24316406 .008300781 C .23307292 .0053710939 .22249349 .0032552083 .21142578 .001953125 C .2006836 .0006510417 .18896485 0 .17626953 0 C .1352539 0 .107421878 .010416667 .09277344 .03125 C .078125 .052408857 .07080078 .0797526 .07080078 .11328125 L .07080078 .45947267 L 0 .45947267 L 0 .53125 L .07080078 .53125 L .07080078 .6772461 Z"/>
+</symbol>
+<symbol id="font_1_4">
+<path d="M 0 .4951172 L 0 .5625 C .06347656 .5686849 .1077474 .5789388 .1328125 .5932617 C .15787761 .60791018 .17659505 .6422526 .18896485 .69628909 L .25830079 .69628909 L .25830079 0 L .16455078 0 L .16455078 .4951172 L 0 .4951172 Z"/>
+</symbol>
+<symbol id="font_1_6">
+<path d="M .09716797 .18847656 C .09977213 .13997396 .118489589 .10644531 .15332031 .087890628 C .17122396 .078125 .19140625 .07324219 .21386719 .07324219 C .25585938 .07324219 .29166667 .090657558 .32128907 .12548828 C .35091148 .16064453 .37190757 .23177083 .38427735 .3388672 C .3647461 .30794273 .34049479 .2861328 .31152345 .2734375 C .2828776 .26106773 .25195313 .2548828 .21875 .2548828 C .15136719 .2548828 .09798177 .2758789 .05859375 .3178711 C .01953125 .35986329 0 .41389976 0 .47998048 C 0 .54345706 .01936849 .5992839 .05810547 .64746096 C .096842449 .695638 .15397136 .71972659 .22949219 .71972659 C .33138023 .71972659 .40169273 .6738281 .4404297 .58203127 C .46191407 .5315755 .47265626 .46842448 .47265626 .39257813 C .47265626 .30696617 .4597982 .2311198 .43408204 .16503906 C .3914388 .05501302 .3191732 0 .21728516 0 C .14892578 0 .09700521 .017903647 .061523439 .053710939 C .026041666 .08951823 .008300781 .13444011 .008300781 .18847656 L .09716797 .18847656 M .23046875 .33203126 C .26529948 .33203126 .29703776 .34342448 .3256836 .36621095 C .35465495 .3893229 .36914063 .42952476 .36914063 .4868164 C .36914063 .5382487 .35611979 .5764974 .33007813 .6015625 C .30436198 .6269531 .27148438 .63964846 .23144531 .63964846 C .18847656 .63964846 .15429688 .6251628 .12890625 .5961914 C .10384115 .5675456 .091308597 .5291341 .091308597 .48095704 C .091308597 .43538413 .102376308 .39908854 .12451172 .3720703 C .14664714 .3453776 .18196614 .33203126 .23046875 .33203126 Z"/>
+</symbol>
+<symbol id="font_1_5">
+<path d="M .48632813 .6875 L .48632813 .61083987 C .4638672 .58902999 .43391929 .55110678 .39648438 .4970703 C .359375 .44303385 .3264974 .38476563 .29785157 .32226563 C .26953126 .26139323 .24804688 .20589192 .23339844 .15576172 C .22395833 .123535159 .2117513 .071614589 .19677735 0 L .099609378 0 C .12174479 .13346355 .17057292 .26627604 .24609375 .3984375 C .2906901 .47591148 .3375651 .54280599 .38671876 .5991211 L 0 .5991211 L 0 .6875 L .48632813 .6875 Z"/>
+</symbol>
+
+
+
+
+
+
+
+
+
+
+
+
+
+</g>
+</svg>

--- a/install/gnome.md
+++ b/install/gnome.md
@@ -10,14 +10,15 @@ This guide describes a user-local installation.
 
 - Copy `balloon.svg` to `~/.local/squeak/squeak.svg`
 
-- Create `~/.local/bin/squeak`:
+Ensure that `~/.local/bin` exists and is in your `PATH` (if not, create it, make sure your `~/.profile` or a similar script adds it to the path, and login again or manually `source ~/.profile` in your shell).
+
+Create `~/.local/bin/squeak`:
 
   ```sh
   #!/bin/sh
   set -e
   version=202502080249
-  cd "$HOME/.local/squeak/$version/"
-  exec ./squeak "$@"
+  exec "$HOME/.local/squeak/$version/squeak" "$@"
   ```
 
   - Make it executable (`chmod +x`)

--- a/install/gnome.md
+++ b/install/gnome.md
@@ -1,0 +1,96 @@
+# Install squeak-app in Gnome
+
+This guide describes a user-local installation.
+
+## Binaries
+
+- Download a compatible Linux bundle from <https://github.com/OpenSmalltalk/opensmalltalk-vm>
+
+- Extract its contents to `~/.local/squeak/<version>/`
+
+- Copy `balloon.svg` to `~/.local/squeak/squeak.svg`
+
+- Create `~/.ocal/bin/squeak`:
+
+  ```sh
+  #!/bin/sh
+  set -e
+  version=202502080249
+  cd "$HOME/.local/squeak/$version/"
+  exec ./squeak "$@"
+  ```
+
+  - Make it executable (`chmod +x`)
+
+- Verify that in a terminal, `squeak myimage.image` works
+
+> [!NOTE]
+> Not sure whether this aligns ideally with Ubuntu’s update-alternatives mechanism
+
+## Gnome Launcher
+
+- Create `nano ~/.local/share/applications/squeak.desktop`:
+
+  ```ini
+  [Desktop Entry]
+  Type=Application
+  Name=Squeak
+  Exec=/home/<USER>/.local/bin/squeak %F
+  Icon=/home/<USER>/.local/squeak/squeak.svg
+  Terminal=false
+  Categories=Development;
+  MimeType=application/x-squeakimage;
+  ```
+
+  - Replace `<USER>` in the above with your local user name (`echo "$USER"`)
+  - Make it executable (`chmod +x`)
+
+- Optionally, validate: `desktop-file-validate ~/.local/share/applications/squeak.desktop`
+
+- `update-desktop-database ~/.local/share/applications`
+
+## Open With
+
+- `mkdir -p ~/.local/share/mime/packages/`
+
+- Create `~/.local/share/mime/packages/squeak.xml`:
+
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/x-squeakimage">
+      <comment>Squeak Image</comment>
+      <glob pattern="*.image"/>
+    </mime-type>
+  </mime-info>
+  ```
+
+- `update-mime-database ~/.local/share/mime`
+
+## File Icon
+
+> [!CAUTION]
+> Currently not working, breaks other icons of local-user applications!
+>
+> ChatGPT said it should work like this, though…
+
+- `mkdir -p .local/share/icons/hicolor/128x128/mimetypes/ && convert .local/squeak/squeak.svg -resize 128x128 -gravity center -background none -extent 128x128 .local/share/icons/hicolor/128x128/mimetypes/application-x-squeakimage.png`
+
+  - Same for other powers of two
+  - Requires ImageMagick (`sudo apt-get install imagemagick`)
+
+- Create `nano ~/.local/share/icons/hicolor/index.theme`:
+
+  ```ini
+  [Icon Theme]
+  Name=Hicolor
+  Comment=User local hicolor icon theme
+  Directories=128x128/mimetypes
+  
+  [128x128/mimetypes]
+  Size=128
+  Context=Mimetypes
+  Type=Fixed
+  ```
+
+- `gtk-update-icon-cache -f ~/.local/share/icons/hicolor`

--- a/install/gnome.md
+++ b/install/gnome.md
@@ -10,7 +10,7 @@ This guide describes a user-local installation.
 
 - Copy `balloon.svg` to `~/.local/squeak/squeak.svg`
 
-- Create `~/.ocal/bin/squeak`:
+- Create `~/.local/bin/squeak`:
 
   ```sh
   #!/bin/sh


### PR DESCRIPTION
For the beginning, I just documented how to install the VM in an Ubuntu system so that you can run images more conveniently from the GUI:

![image](https://github.com/user-attachments/assets/8a3b29fa-0020-4338-9ec8-f6e635e8115b)

Proper window icon in launcher/dock:

![image](https://github.com/user-attachments/assets/23f513e3-43c4-4d56-aec0-0783d26ea207)

(For clarification, by default you cannot see nor add a Squeak binary to "Open With" in Gnome, and the app icon is just generic.)

Tested on Ubuntu 24.

Future work:

- I also tried to add an icon to the file in the Files app (nautilus) but that doesn't work right now.
- It would be nice if the starter script or the binary itself had an option to trigger a file chooser if no image file is specified, so that opening Squeak from the launcher works (currently it does nothing visible).
- Automate all of this, ideally also ship it as a deb package (or maybe research alternatives such as snap/flatpak).