### PR TITLE
Revert linux scale factor workaround for memory leak in VM

### DIFF
--- a/templates/linux/squeak.sh
+++ b/templates/linux/squeak.sh
@@ -169,9 +169,5 @@ ensure_vm
 ensure_image
 detect_sound
 
-# Enable per-monitor scaling to work around memory leak:
-# https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/642
-export SQUEAK_DISPLAY_PER_MONITOR_SCALE=1 
-
 echo "Using ${VM} ..."
 exec ${SOUNDSERVER} "${VM}" ${VMOPTIONS} ${VMARGS} "${IMAGE}" "${STARGS[@]}"


### PR DESCRIPTION
This relates to the concrete bug reported in https://github.com/squeak-smalltalk/squeak-object-memory/issues/151: On Linux systems with a scale factor >100%, the launched VM would misdetect the scale factor (e.g., 250% instead of 200%).

The original VM issue described in #642 has been solved in https://github.com/OpenSmalltalk/opensmalltalk-vm/commit/f5b6485efb8064f834dcdcd7c910f3c3750db835 (released since 202311211431).

I have tested this change on Ubuntu 24 with both X11 and Wayland/XWayland and the scale factor is detected correctly now. I could also not observe any further memory leaks by following the measureements described in [#642](https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/642).